### PR TITLE
fix: correctly display all available UI languages in video player

### DIFF
--- a/app/javascript/modules/media-player/constants/translations.js
+++ b/app/javascript/modules/media-player/constants/translations.js
@@ -90,6 +90,7 @@ export const VIDEOJS_I18N_KEY_MAP = {
     Depressed: 'media_player.depressed',
     Uniform: 'media_player.uniform',
     'Drop shadow': 'media_player.drop_shadow',
+    Dropshadow: 'media_player.dropshadow', // Exists in some Video.js language files only
     'Font Family': 'media_player.font_family',
     'Proportional Sans-Serif': 'media_player.proportional_sans_serif',
     'Monospace Sans-Serif': 'media_player.monospace_sans_serif',

--- a/app/javascript/modules/media-player/constants/translations.test.js
+++ b/app/javascript/modules/media-player/constants/translations.test.js
@@ -1,17 +1,21 @@
 import { VIDEOJS_I18N_KEY_MAP } from './translations';
+import langAr from 'video.js/dist/lang/ar.json';
 import langDe from 'video.js/dist/lang/de.json';
 import langEl from 'video.js/dist/lang/el.json';
 import langEn from 'video.js/dist/lang/en.json';
 import langEs from 'video.js/dist/lang/es.json';
 import langRu from 'video.js/dist/lang/ru.json';
+import langUk from 'video.js/dist/lang/uk.json';
 
 // Test multiple language files to ensure our mapping covers all scenarios
 const LANGUAGE_FILES = [
+    { code: 'ar', data: langAr, name: 'Arabic' },
     { code: 'de', data: langDe, name: 'German' },
     { code: 'el', data: langEl, name: 'Greek' },
     { code: 'en', data: langEn, name: 'English' },
     { code: 'es', data: langEs, name: 'Spanish' },
     { code: 'ru', data: langRu, name: 'Russian' },
+    { code: 'uk', data: langUk, name: 'Ukranian' },
 ];
 
 describe('Video.js Translation Mapping', () => {

--- a/app/javascript/modules/media-player/hooks/useVideojsLanguages.js
+++ b/app/javascript/modules/media-player/hooks/useVideojsLanguages.js
@@ -40,11 +40,11 @@ function useVideojsLanguages() {
     const isTranslationsView = useSelector(getTranslationsView);
     const project = useSelector(getCurrentProject);
 
-    // Dynamically build LANGS from the project's pseudo_available_locales.
+    // Dynamically build LANGS from the project's available_locales.
     // We use synchronous require so bundlers can include only the referenced
     // JSON files at build time. Missing files are skipped with a warning.
     const LANGS = useMemo(() => {
-        const codes = project?.pseudo_available_locales || [];
+        const codes = project?.available_locales || [];
         return codes
             .map((code) => {
                 try {
@@ -59,7 +59,7 @@ function useVideojsLanguages() {
                 }
             })
             .filter(Boolean);
-    }, [project?.pseudo_available_locales]);
+    }, [project?.available_locales]);
 
     // Create a stable key from available media_player.* translation keys
     const translationKey = useMemo(() => {


### PR DESCRIPTION
Changes the import of Video.JS native languages to be dynamic, based on the current project's available languages. Fixes the problem, that for some languages (Arabic, Ukranian) the strings in the video player were not updated correctly.