### PR TITLE
fix: correctly apply RTL display of segments

### DIFF
--- a/app/javascript/modules/transcript/components/Segment.js
+++ b/app/javascript/modules/transcript/components/Segment.js
@@ -6,8 +6,9 @@ import { useScrollOffset } from 'modules/media-player';
 import { useTranscriptQueryString } from 'modules/query-string';
 import PropTypes from 'prop-types';
 import { memo, useRef } from 'react';
-import BookmarkSegmentButton from './BookmarkSegmentButton';
 import { useAutoScrollToRef } from '../hooks';
+import { checkTextDir, enforceRtlOnTranscriptTokens } from '../utils';
+import BookmarkSegmentButton from './BookmarkSegmentButton';
 import Initials from './Initials';
 import SegmentButtons from './SegmentButtons';
 import SegmentPopup from './SegmentPopup';
@@ -48,9 +49,13 @@ function Segment({
         segmentParam,
     ]);
 
-    const text = isAuthorized(data, 'update')
+    let text = isAuthorized(data, 'update')
         ? data.text[contentLocale] || data.text[`${contentLocale}-public`]
         : data.text[`${contentLocale}-public`];
+
+    const textDir = checkTextDir(text);
+    // Enforce RTL wrapping if the text direction is RTL
+    text = textDir === 'rtl' ? enforceRtlOnTranscriptTokens(text) : text;
 
     const showSegment = text || editView;
 
@@ -94,7 +99,7 @@ function Segment({
                         'is-active': active,
                     })}
                     lang={contentLocale}
-                    dir="auto"
+                    dir={textDir ? textDir : 'auto'}
                     onClick={() => {
                         transcriptCoupled &&
                             sendTimeChangeRequest(data.tape_nbr, data.time);

--- a/app/javascript/modules/transcript/components/SegmentForm.js
+++ b/app/javascript/modules/transcript/components/SegmentForm.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import { useEffect } from 'react';
-import { isRtlLang } from 'rtl-detect';
+import { checkTextDir } from '../utils';
 
 import { Form } from 'modules/forms';
 import { usePeople } from 'modules/person';
@@ -18,20 +18,15 @@ export default function SegmentForm({
 }) {
     const { data: people, isLoading } = usePeople();
 
-    // Use Intl.Locale to extract two-letter language code for rtl-detect
-    const langCode = new Intl.Locale(contentLocale).language;
-    const isRtl = isRtlLang(langCode);
+    // Determine text direction for the textarea
+    const textDir = checkTextDir(segment?.text[contentLocale] || '');
 
     useEffect(() => {
-        if (isRtl) {
-            const textarea = document.getElementById('segment_text');
-            if (textarea) {
-                textarea.setAttribute('dir', 'auto');
-                textarea.style.direction = 'rtl';
-                textarea.style.textAlign = 'right';
-            }
-        }
-    }, [isRtl]);
+        const textarea = document.getElementById('segment_text');
+        textarea.setAttribute('dir', textDir);
+        textarea.style.direction = textDir;
+        textarea.style.textAlign = textDir === 'rtl' ? 'right' : 'left';
+    }, [textDir, contentLocale]);
 
     if (isLoading) {
         return <Spinner />;

--- a/app/javascript/modules/transcript/utils/checkTextDir.js
+++ b/app/javascript/modules/transcript/utils/checkTextDir.js
@@ -1,0 +1,56 @@
+import { filterTranscriptionTags } from './filterTranscriptionTags';
+
+/**
+ * Utility to check text direction based on different criteria
+ *
+ * Heuristics:
+ *  - majority: count up to maxChars and pick the majority of strong chars
+ *  - first-strong: return direction of first strongly directional character
+ *
+ * Options:
+ *  - method: "majority" | "first-strong"
+ *  - defaultDir: "ltr" | "rtl"
+ *  - maxChars: number of characters to scan
+ *  - stripTags: boolean - remove transcription tags before analysis
+ */
+
+export function checkTextDir(
+    text,
+    {
+        method = 'majority',
+        defaultDir = 'ltr',
+        maxChars = 300,
+        stripTags = true,
+    } = {}
+) {
+    if (typeof text !== 'string' || text.length === 0) return defaultDir;
+
+    const filteredText = stripTags ? filterTranscriptionTags(text) : text;
+
+    // RTL ranges commonly used (Hebrew, Arabic, Syriac, Thaana, NKo, presentation forms, etc.)
+    const rtlRe = /[\u0590-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF]/;
+    // LTR: basic Latin + Latin-1 Supplement + Latin Extended ranges (covers most Latin letters)
+    const ltrRe = /[A-Za-z\u00C0-\u024F\u1E00-\u1EFF]/;
+
+    const limit = Math.min(filteredText.length, maxChars);
+
+    if (method === 'majority') {
+        let rtlCount = 0;
+        let ltrCount = 0;
+        for (let i = 0; i < limit; i++) {
+            const ch = filteredText[i];
+            if (rtlRe.test(ch)) rtlCount++;
+            else if (ltrRe.test(ch)) ltrCount++;
+        }
+        if (rtlCount > ltrCount) return 'rtl';
+        if (ltrCount > rtlCount) return 'ltr';
+    }
+
+    // Fallback to 'first-strong' method
+    for (let i = 0; i < limit; i++) {
+        const ch = filteredText[i];
+        if (rtlRe.test(ch)) return 'rtl';
+        if (ltrRe.test(ch)) return 'ltr';
+    }
+    return defaultDir;
+}

--- a/app/javascript/modules/transcript/utils/checkTextDir.test.js
+++ b/app/javascript/modules/transcript/utils/checkTextDir.test.js
@@ -1,0 +1,95 @@
+import { checkTextDir } from './checkTextDir';
+
+describe('checkTextDir majority method', () => {
+    it('returns "ltr" for pure left-to-right text', () => {
+        const result = checkTextDir('Hello, world!');
+        expect(result).toBe('ltr');
+    });
+
+    it('returns "rtl" for pure right-to-left text', () => {
+        const result = checkTextDir('!مرحبا بالعالم');
+        expect(result).toBe('rtl');
+    });
+
+    it('returns "rtl" for mixed text with majority rtl text', () => {
+        const result = checkTextDir('Hello, مرحبا بالعالم!');
+        expect(result).toBe('rtl');
+    });
+
+    it('returns "ltr" for mixed text with majority ltr text', () => {
+        const result = checkTextDir(
+            'Hello this is a long text, مرحبا بالعالم!'
+        );
+        expect(result).toBe('ltr');
+    });
+
+    it('returns "ltr" for ltr text with tags', () => {
+        const result = checkTextDir('Hello, <l(fr) Texte français>!');
+        expect(result).toBe('ltr');
+    });
+
+    it('returns "ltr" for ltr text with <s/... KEEP> tags', () => {
+        const result = checkTextDir('Hello, <s(Sprechweise) SPEAK STYLE>!');
+        expect(result).toBe('ltr');
+    });
+
+    it('returns "ltr" for ltr text with <sim KEEP> tags', () => {
+        const result = checkTextDir('This is <sim SIM> now');
+        expect(result).toBe('ltr');
+    });
+
+    it('returns "rtl" for rtl text that contains an s/nl/g tag afterward', () => {
+        const result = checkTextDir('مرحبا <nl(Geräusch) NOISE> كيف حالك؟');
+        expect(result).toBe('rtl');
+    });
+
+    it('returns "rtl" for rtl text with sim/res tags after the text', () => {
+        const result = checkTextDir('שלום <res RESP> מה נשמע?');
+        expect(result).toBe('rtl');
+    });
+
+    it('returns "rtl" for rtl text preceded with tags to be ignored', () => {
+        const result = checkTextDir('<l(es) ignorame por favor> מה נשמע?');
+        expect(result).toBe('rtl');
+    });
+});
+
+describe('checkTextDir first-strong method', () => {
+    it('first-strong: returns "ltr" when RTL text appears after a tag at the start', () => {
+        const result = checkTextDir('<nl(Geräusch) NOISE> مرحبا', {
+            method: 'first-strong',
+        });
+        expect(result).toBe('ltr');
+    });
+
+    it('first-strong: returns "ltr" when multiple tags precede RTL text', () => {
+        const result = checkTextDir('<sim SIM><s(טון) TONE> שלום', {
+            method: 'first-strong',
+        });
+        expect(result).toBe('ltr');
+    });
+
+    it('first-strong: returns "ltr" when an adjacent tag (no space) precedes RTL text', () => {
+        const result = checkTextDir('<res RESP>مرحبا', {
+            method: 'first-strong',
+        });
+        expect(result).toBe('ltr');
+    });
+
+    it('first-strong: returns "ltr" if a kept LTR string from a tag comes before RTL text', () => {
+        const result = checkTextDir('<s(Sprechweise) SPEAK> مرحبا', {
+            method: 'first-strong',
+        });
+        expect(result).toBe('ltr');
+    });
+
+    it('first-strong: returns "rtl" even with LTR majority if RTL is at the start', () => {
+        const result = checkTextDir(
+            'مرحبا <nl(Geräusch) HERE IS SOME LONG TEXT>',
+            {
+                method: 'first-strong',
+            }
+        );
+        expect(result).toBe('rtl');
+    });
+});

--- a/app/javascript/modules/transcript/utils/enforceRtlOnTranscriptTokens.js
+++ b/app/javascript/modules/transcript/utils/enforceRtlOnTranscriptTokens.js
@@ -1,0 +1,26 @@
+/**
+ * Wraps transcript tokens with RTL-isolate so they render correctly inside RTL text.
+ * - Uses RLI (U+2067) ... PDI (U+2069)
+ * - Optionally fences with RLM (U+200F) on both sides to stabilize punctuation.
+ */
+export function enforceRtlOnTranscriptTokens(
+    text,
+    { fenceWithRLM = true } = {}
+) {
+    if (typeof text !== 'string' || text.length === 0) return text ?? '';
+
+    const RLI = '\u2067'; // Right-to-Left Isolate
+    const PDI = '\u2069'; // Pop Directional Isolate
+    const RLM = '\u200F'; // Right-to-Left Mark
+
+    // Matches:
+    // - <sim ...>, <res ...>, <an ...>, <? ...>, <p2>, <p10> ...
+    // - <s(...)>, <nl(...)>, <g(...)>, <l(...)>, <v(...)>, <n(...)>, <i(...)>
+    const tokenRegex =
+        /<\s*(?:(?:sim|res|an|\?|p\d+)(?:\s+[^<>]*?)?|(?:s|nl|g|l|v|n|i)\s*\([^<>]*?\))\s*>/g;
+
+    return text.replace(tokenRegex, (m) => {
+        const wrapped = `${RLI}${m}${PDI}`;
+        return fenceWithRLM ? `${RLM}${wrapped}${RLM}` : wrapped;
+    });
+}

--- a/app/javascript/modules/transcript/utils/enforceRtlOnTranscriptTokens.test.js
+++ b/app/javascript/modules/transcript/utils/enforceRtlOnTranscriptTokens.test.js
@@ -1,0 +1,44 @@
+import { enforceRtlOnTranscriptTokens } from './enforceRtlOnTranscriptTokens';
+
+describe('enforceRtlOnTranscriptTokens', () => {
+    const RLI = '\u2067';
+    const PDI = '\u2069';
+    const RLM = '\u200F';
+
+    it('wraps a single sim token with RLM+RLI...PDI+RLM by default', () => {
+        const input = 'before <sim SIM> after';
+        const expected = `before ${RLM}${RLI}<sim SIM>${PDI}${RLM} after`;
+        expect(enforceRtlOnTranscriptTokens(input)).toBe(expected);
+    });
+
+    it('wraps a token at the start of the string', () => {
+        const input = '<res RESP> hello';
+        const expected = `${RLM}${RLI}<res RESP>${PDI}${RLM} hello`;
+        expect(enforceRtlOnTranscriptTokens(input)).toBe(expected);
+    });
+
+    it('wraps multiple adjacent tokens separately', () => {
+        const input = '<sim A><res B> done';
+        const expected = `${RLM}${RLI}<sim A>${PDI}${RLM}${RLM}${RLI}<res B>${PDI}${RLM} done`;
+        expect(enforceRtlOnTranscriptTokens(input)).toBe(expected);
+    });
+
+    it('wraps parentheses-only s(...) tokens (no trailing KEEP)', () => {
+        const input = 'x <s(Sprechweise)> y';
+        const expected = `x ${RLM}${RLI}<s(Sprechweise)>${PDI}${RLM} y`;
+        expect(enforceRtlOnTranscriptTokens(input)).toBe(expected);
+    });
+
+    it('does not fence with RLM when fenceWithRLM is false', () => {
+        const input = 'x <sim SIM> y';
+        const expected = `x ${RLI}<sim SIM>${PDI} y`;
+        expect(
+            enforceRtlOnTranscriptTokens(input, { fenceWithRLM: false })
+        ).toBe(expected);
+    });
+
+    it('leaves text without tokens unchanged', () => {
+        const input = 'just plain text';
+        expect(enforceRtlOnTranscriptTokens(input)).toBe(input);
+    });
+});

--- a/app/javascript/modules/transcript/utils/filterTranscriptionTags.js
+++ b/app/javascript/modules/transcript/utils/filterTranscriptionTags.js
@@ -1,0 +1,49 @@
+/**
+ * Remove or normalize transcription-style tags from a string.
+ *
+ * Behavior:
+ * - Completely removes tags such as <l(...) ...>, <v(...)>, <n(...)>, <i(...)>, and pause tags like <p2>.
+ * - For tags of the form `<s(...) KEEP>`, `<nl(...) KEEP>`, `<g(...) KEEP>` (or `[KEEP]` variants),
+ *   the KEEP text is preserved and the rest of the tag removed.
+ * - Also preserves trailing KEEP text for tags like `<sim KEEP>`, `<res KEEP>`, `<an KEEP>`, and `<? KEEP>`.
+ * - Collapses multiple spaces and removes stray space before punctuation.
+ *
+ * @param {string} text - The transcription text to clean. If a non-string is provided, it is returned unchanged.
+ * @returns {string} The cleaned text with tags removed or replaced according to the rules above.
+ *
+ * @example
+ * filterTranscriptionTags('This is <s(Sprechweise) SPEAK STYLE>, ok.')
+ * // -> 'This is SPEAK STYLE, ok.'
+ *
+ * Notes:
+ * - The function uses regex heuristics. KEEP strings should not contain '>' or ']'—if tag contents can be nested
+ *   or contain those characters, consider a proper parser/tokenizer for correctness.
+ */
+
+export function filterTranscriptionTags(text) {
+    if (typeof text !== 'string') return text;
+
+    let out = text;
+
+    // For tags like <s(...) KEEP> or <nl(...) KEEP> or <g(...) KEEP>
+    // capture the content after the parentheses up to the closing '>' and keep it.
+    out = out.replace(/<\s*(?:s|nl|g)\([^>]*\)\s*([^>]+?)>/gi, ' $1 ');
+
+    // Tags like <sim KEEP>, <res KEEP>, <an KEEP>, and <? KEEP>
+    // Keep the trailing string before '>' and remove the rest of the tag.
+    out = out.replace(/<\s*(?:sim|res|an|\?)\s*([^>]+?)>/gi, ' $1 ');
+
+    // Remove tags that should be ignored completely (no KEEP to preserve)
+    out = out.replace(/<\s*(?:l|v|n|i)[^>]*>/gi, '');
+
+    // Remove pause tags like <p2>, <p3>, etc.
+    out = out.replace(/<\s*p\d+\s*>/gi, '');
+
+    // Collapse multiple spaces left by removals.
+    out = out.replace(/\s+/g, ' ');
+
+    // Remove space before punctuation (commas, periods, etc.).
+    out = out.replace(/\s+([,.;:!?])/g, '$1');
+
+    return out.trim();
+}

--- a/app/javascript/modules/transcript/utils/filterTranscriptionTags.test.js
+++ b/app/javascript/modules/transcript/utils/filterTranscriptionTags.test.js
@@ -1,0 +1,103 @@
+import { filterTranscriptionTags } from './filterTranscriptionTags';
+
+describe('filterTranscriptionTags', () => {
+    // Should ignore certain tags completely
+    it('ignores some transcription tags completely', () => {
+        const withTagsToIgnore = [
+            // Language changes
+            ['This is <l(en) English text>, you see?', 'This is, you see?'],
+            ['This is <l(fr) Texte français>, you see?', 'This is, you see?'],
+            ['This is <l(it) Testo italiano>, you see?', 'This is, you see?'],
+            [
+                'This is <l(pt) Texto em português>, you see?',
+                'This is, you see?',
+            ],
+            ['This is <l(es) Texto en español>, you see?', 'This is, you see?'],
+            ['This is <l(de) Deutscher Text>, you see?', 'This is, you see?'],
+            ['This is <l(ar) مرحبا بالعالم>, you see?', 'This is, you see?'],
+            // Vocalizations
+            ['This is <v(Lachen)>, you see?', 'This is, you see?'],
+            ['This is <v(Weinen)>, you see?', 'This is, you see?'],
+            ['This is <v(Seufzen)>, you see?', 'This is, you see?'],
+            ['This is <v(Räuspern)>, you see?', 'This is, you see?'],
+            ['This is <v(Husten)>, you see?', 'This is, you see?'],
+            ['This is <v(Gähnen)>, you see?', 'This is, you see?'],
+            // Notes
+            ['This is <n(Kurfürstendamm)>, you see?', 'This is, you see?'],
+            ['This is <n(Champs-Élysées)>, you see?', 'This is, you see?'],
+            ['This is <n(Plaza Mayor)>, you see?', 'This is, you see?'],
+            ['This is <n(Grand Canyon)>, you see?', 'This is, you see?'],
+            ['This is <n(Νέα Υόρκη)>, you see?', 'This is, you see?'],
+            ['This is <n(مصر)>, you see?', 'This is, you see?'],
+            ['This is <n(東京)>, you see?', 'This is, you see?'],
+            ['This is <n(Москва)>, you see?', 'This is, you see?'],
+            ['This is <n(القاهرة)>, you see?', 'This is, you see?'],
+            ['This is <n(北京)>, you see?', 'This is, you see?'],
+            // Interruptions
+            ['This is <i(Batteriewechsel)>, you see?', 'This is, you see?'],
+            ['This is <i(تغيير البطارية)>, you see?', 'This is, you see?'],
+            ['This is <i(バッテリー交換)>, you see?', 'This is, you see?'],
+            ['This is <i(смена батареи)>, you see?', 'This is, you see?'],
+            ['This is <i(cambio de batería)>, you see?', 'This is, you see?'],
+            // Pauses
+            ['This is <p2>, you see?', 'This is, you see?'],
+            ['This is <p3>, you see?', 'This is, you see?'],
+            ['This is <p4>, you see?', 'This is, you see?'],
+            ['This is <p5>, you see?', 'This is, you see?'],
+            ['This is <p125>, you see?', 'This is, you see?'],
+        ];
+
+        withTagsToIgnore.forEach(([withTags, expected]) => {
+            expect(filterTranscriptionTags(withTags)).toBe(expected);
+        });
+    });
+
+    it('removes tags correctly when main text is Arabic or Hebrew', () => {
+        const rtlCases = [
+            // Arabic main text with a vocalization tag
+            ['مرحبا <v(صوت)>, كيف الحال?', 'مرحبا, كيف الحال?'],
+            // Hebrew main text with a note tag
+            ['שלום <n(תל אביב)>, מה שלומך?', 'שלום, מה שלומך?'],
+            // Arabic with pause and vocalization tags mixed
+            ['هذا <p2> نص <v(صوت)> عربي.', 'هذا نص عربي.'],
+            // Hebrew with language tag and vocalization, multiple tags
+            ['שלום <l(en) Hello> <v(שם)>, מה קורה?', 'שלום, מה קורה?'],
+        ];
+
+        rtlCases.forEach(([input, expected]) => {
+            expect(filterTranscriptionTags(input)).toBe(expected);
+        });
+    });
+
+    it('keeps strings for s/nl/g tags while removing the rest of the tag', () => {
+        const cases = [
+            [
+                'This is <s(Sprechweise) SPEAK STYLE>, you see?',
+                'This is SPEAK STYLE, you see?',
+            ],
+            ['Here <nl(Geräusch) NOISE> is noise.', 'Here NOISE is noise.'],
+            ['He <g(Art der Geste) GESTURE> waved.', 'He GESTURE waved.'],
+            // multiple occurrences
+            ['<s(A) A> and <nl(B) B>, done.', 'A and B, done.'],
+        ];
+
+        cases.forEach(([input, expected]) => {
+            expect(filterTranscriptionTags(input)).toBe(expected);
+        });
+    });
+
+    it('keeps strings for sim/res/an/? tags while removing the rest of the tag', () => {
+        const cases = [
+            ['This is <sim SIM> now', 'This is SIM now'],
+            ['Response: <res RES>!', 'Response: RES!'],
+            ['Note <an AN> here.', 'Note AN here.'],
+            ['Unknown <? Q> mark', 'Unknown Q mark'],
+            // multiple occurrences and adjacency
+            ['<sim A><res B> done.', 'A B done.'],
+        ];
+
+        cases.forEach(([input, expected]) => {
+            expect(filterTranscriptionTags(input)).toBe(expected);
+        });
+    });
+});

--- a/app/javascript/modules/transcript/utils/index.js
+++ b/app/javascript/modules/transcript/utils/index.js
@@ -1,3 +1,6 @@
+export * from './checkTextDir';
+export * from './enforceRtlOnTranscriptTokens';
+export * from './filterTranscriptionTags';
 export * from './getContributorInformation';
 export * from './segmentsForTape';
 export * from './sortedSegmentsForTape';


### PR DESCRIPTION
Display of Right-to-left (RTL) languages was not working correctly, especially with transcript tokens (like  `<l(...) ...>`, `<v(...)>`, `<n(...)>`, `<i(...)>`, `<sim ...>`). This PR changes the approach to determine text direction of segements from using `dir="auto"` to dynamically checking the text.

The new utility function `checkTextDir.js()` removes transcript tokens and then checks whether the majority of text of the segement is LTR or RTL. Based on that we set `dir="ltr"` or `dir="rtl"` explicitly. This is also applied to text input fields when editing segments.

Additionally, just for the display of segments, we add invisible characters around transcript tokens in case of RTL segments to control the text flow (this is handled in `enforceRtlOnTranscriptTokens()`).