### PR TITLE
fix: quick click redirect on login

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -98,6 +98,22 @@ The setup automatically configures several important files:
 - `datacite.yml` - Settings for DataCite integration
 - `sunspot.yml` - Solr search engine configuration
 
+### Active Record Encryption Keys (development)
+
+Rails 8 uses encryption keys for encrypted attributes. In this project, these keys are optional for booting the devcontainer and are only required when using features that read/write encrypted fields.
+
+1. Copy `.devcontainer/dev/.env.example` to `.devcontainer/dev/.env` (optional)
+2. Generate keys:
+
+```sh
+bin/rails db:encryption:init
+```
+
+3. Paste the generated values into `.devcontainer/dev/.env`
+4. Rebuild/reopen the devcontainer so Docker Compose picks up the env file
+
+If you do not provide these keys, the app still starts normally, but encrypted-attribute features can raise missing encryption key errors when accessed.
+
 Database permissions are also automatically configured for proper access from the application.
 
 ## Running the Application

--- a/.devcontainer/dev/.env.example
+++ b/.devcontainer/dev/.env.example
@@ -1,0 +1,6 @@
+# Local-only Active Record encryption keys for development.
+# Generate with: bin/rails db:encryption:init
+
+ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=
+ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=
+ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=

--- a/.devcontainer/dev/docker-compose.yml
+++ b/.devcontainer/dev/docker-compose.yml
@@ -41,6 +41,10 @@ services:
       DISABLE_SPRING: true
       # Use precompiled platform-specific gems instead of compiling from source
       BUNDLE_FORCE_RUBY_PLATFORM: false
+      # Optional: only needed for features backed by encrypted attributes.
+      ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY: ${ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY:-}
+      ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY: ${ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY:-}
+      ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT: ${ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT:-}
       # Cap Node.js heap to prevent webpack-dev-server OOM-killing the host.
       # Without this, V8 grows the heap unboundedly over a long dev session.
       NODE_OPTIONS: '--max-old-space-size=2048'

--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,5 @@ solr/pids
 .devcontainer/logs
 .devcontainer/db/*.sql.gz
 .devcontainer/.env
+.devcontainer/dev/.env
 .directory

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -68,7 +68,13 @@ class SessionsController < Devise::SessionsController
     resource = User.find_by(id: session[:otp_user_id])
     
     if resource.nil? 
-      redirect_to new_user_session_path, alert: tv("devise.failure.unauthenticated")
+      # A fast second submit can arrive after a successful OTP verification
+      # already consumed otp_user_id. If the user is signed in, finish redirect.
+      if current_user
+        after_sign_in(current_user)
+      else
+        redirect_to new_user_session_path, alert: tv("devise.failure.unauthenticated")
+      end
       return
     end
 

--- a/app/javascript/controllers/otp_controller.js
+++ b/app/javascript/controllers/otp_controller.js
@@ -1,10 +1,34 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
-    static targets = ['digit', 'hidden', 'form'];
+    static get targets() {
+        return ['digit', 'hidden', 'form', 'submit'];
+    }
 
     connect() {
+        this.isSubmitting = false;
         this.digitTargets[0].focus();
+    }
+
+    // Handle form submission state to prevent multiple submissions
+    handleSubmitState(event) {
+        if (this.isSubmitting) {
+            event.preventDefault();
+            return;
+        }
+        this.isSubmitting = true;
+        this.disableOtpInputs();
+    }
+
+    // Disable all OTP input fields and the submit button
+    disableOtpInputs() {
+        this.digitTargets.forEach((input) => {
+            input.readOnly = true;
+        });
+
+        if (this.hasSubmitTarget) {
+            this.submitTarget.disabled = true;
+        }
     }
 
     handleInput(event) {
@@ -69,8 +93,9 @@ export default class extends Controller {
         const otp = this.digitTargets.map((input) => input.value).join('');
         this.hiddenTarget.value = otp;
 
-        if (otp.length === 6) {
+        if (otp.length === 6 && !this.isSubmitting) {
             setTimeout(() => {
+                if (this.isSubmitting) return; // Prevent multiple submissions
                 this.formTarget.requestSubmit();
             }, 200);
         }

--- a/app/models/concerns/multi_factor_authenticatable.rb
+++ b/app/models/concerns/multi_factor_authenticatable.rb
@@ -66,6 +66,9 @@ module MultiFactorAuthenticatable
     end
 
     false
+  rescue ActiveRecord::Encryption::Errors::Decryption
+    # Legacy/corrupted encrypted secrets should not crash the login flow.
+    false
   end
 
   def otp(otp_secret = self.otp_secret)

--- a/app/views/devise/sessions/otp.html.slim
+++ b/app/views/devise/sessions/otp.html.slim
@@ -2,7 +2,7 @@ h2= tv("activerecord.attributes.user.otp_attempt")
 
 = form_with url: users_verify_otp_path,
   method: :post,
-  data: { controller: "otp", otp_target: "form" },
+  data: { controller: "otp", otp_target: "form", action: "submit->otp#handleSubmitState" },
   html: {class: 'Form'} do |f|
 
   = hidden_field_tag :path, @path

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,6 +48,22 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
+  # Optional in development: only enable explicit AR encryption keys when all are provided.
+  encryption_keys = {
+    primary_key: ENV['ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY'].presence,
+    deterministic_key: ENV['ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY'].presence,
+    key_derivation_salt: ENV['ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT'].presence
+  }
+
+  provided_count = encryption_keys.values.compact.size
+  if provided_count == encryption_keys.size
+    config.active_record.encryption.primary_key = encryption_keys[:primary_key]
+    config.active_record.encryption.deterministic_key = encryption_keys[:deterministic_key]
+    config.active_record.encryption.key_derivation_salt = encryption_keys[:key_derivation_salt]
+  elsif provided_count.positive?
+    raise 'Set all ACTIVE_RECORD_ENCRYPTION_* variables or none in development.'
+  end
+
   # Raise exceptions for disallowed deprecations.
   config.active_support.disallowed_deprecation = :raise
 

--- a/test/system/helpers/redirect_system_test_helper.rb
+++ b/test/system/helpers/redirect_system_test_helper.rb
@@ -18,6 +18,9 @@ module RedirectSystemTestHelper
   end
 
   def assert_redirected_to_project_subpage
+    # Wait for the destination page to finish rendering before checking URL.
+    assert_text 'Redirect Project'
+
     redirected_url = URI.parse(current_url)
     redirected_query = Rack::Utils.parse_nested_query(redirected_url.query)
 
@@ -25,6 +28,5 @@ module RedirectSystemTestHelper
     assert_equal '/en/searches/archive', redirected_url.path
     assert_equal 'random', redirected_query['sort']
     assert_nil redirected_query['checked_ohd_session']
-    assert_text 'Redirect Project'
   end
 end

--- a/test/system/login_redirect_test.rb
+++ b/test/system/login_redirect_test.rb
@@ -66,7 +66,7 @@ class LoginRedirectTest < ApplicationSystemTestCase
     assert_equal '/ohf/de', current_path
   end
 
-  test "login with TOTP from project subpage redirects back to that subpage" do
+  test "login with TOTP from project subpage keeps redirect context on quick click" do
     project = setup_redirect_project_for_user(email: EMAIL)
     user = User.find_by(email: EMAIL)
 
@@ -88,13 +88,19 @@ class LoginRedirectTest < ApplicationSystemTestCase
     click_on 'Login'
 
     assert_current_path users_otp_path(locale: I18n.locale), ignore_query: true
-    assert_text 'One-time code'
+
+    # Verify redirect context is present on OTP form before submitting.
+    assert_selector "input[name='path'][value='/en/searches/archive?sort=random']", visible: false
+    assert_selector "input[name='project'][value='redirproj']", visible: false
 
     user.current_otp.chars.each_with_index do |digit, index|
-      find("input.otp-digit[data-index='#{index}']").set(digit)
+      input = find("input.otp-digit[data-index='#{index}']")
+      input.click
+      input.send_keys(digit)
     end
 
-    sleep 0.3
+    # Reproduce user behavior: click quickly after entering the last digit.
+    click_on 'Login'
 
     assert_redirected_to_project_subpage
   end


### PR DESCRIPTION
When using OTP login, entering the token triggers sending the login form. When users clicked the submit button in the same moment, a race condition led to the user not being redirected correctly after login. This PR fixes that problem. Also adjusts devcontainer for MFA to work in development.