### PR TITLE
fix: exclude umbrella projects by default and add include_umbrella option

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -55,6 +55,7 @@ class ProjectsController < ApplicationController
 
     scoped_projects = policy_scope(Project)
     scoped_projects = scoped_projects.where(workflow_state: normalized_workflow_states) if normalized_workflow_states
+    scoped_projects = scoped_projects.where.not(shortname: 'ohd') unless normalized_include_umbrella
 
     if params.keys.include?('all')
       projects = scoped_projects.order(created_at: :desc)
@@ -84,6 +85,7 @@ class ProjectsController < ApplicationController
       extra_params,
       projects_cache_scope_key,
       normalized_workflow_states&.join(','),
+      "include-umbrella-#{normalized_include_umbrella}",
       I18n.locale,
       Project.count,
       Project.maximum(:updated_at),
@@ -258,6 +260,14 @@ class ProjectsController < ApplicationController
 
       # Invalid-only input falls back to no filter.
       @normalized_workflow_states = filtered_states.presence
+    end
+
+    def normalized_include_umbrella
+      return @normalized_include_umbrella if defined?(@normalized_include_umbrella)
+
+      value = params[:include_umbrella]
+      # Exclude umbrella by default unless include_umbrella is explicitly true.
+      @normalized_include_umbrella = (value.to_s.downcase == 'true')
     end
 
     def serialized_projects(projects, interview_counts, collection_counts, interview_languages_by_project)

--- a/app/javascript/modules/data/hooks/useGetProjects.js
+++ b/app/javascript/modules/data/hooks/useGetProjects.js
@@ -3,19 +3,18 @@ import { usePathBase } from 'modules/routes';
 import useSWRImmutable from 'swr/immutable';
 
 export function useGetProjects(options = {}) {
-    const { page = 1, all = false, workflowState } = options;
+    const {
+        page = 1,
+        all = false,
+        workflowState,
+        includeUmbrella = false,
+    } = options;
     const pathBase = usePathBase();
 
     const queryParams = new URLSearchParams();
-    if (all) {
-        queryParams.set('all', 'true');
-    } else {
-        queryParams.set('page', String(page));
-    }
-
-    if (workflowState) {
-        queryParams.set('workflow_state', workflowState);
-    }
+    queryParams.set(all ? 'all' : 'page', all ? 'true' : String(page));
+    workflowState ? queryParams.set('workflow_state', workflowState) : null;
+    includeUmbrella ? queryParams.set('include_umbrella', 'true') : null;
 
     const path = `${pathBase}/projects/list?${queryParams.toString()}`;
 

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -63,6 +63,33 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert data['data'].is_a?(Array)
   end
 
+  test 'should exclude umbrella project by default when include_umbrella is omitted' do
+    get list_projects_path(locale: 'en', format: :json), params: { all: true }
+    assert_response :success
+
+    data = JSON.parse(response.body)
+    shortnames = data.fetch('data', []).map { |project| project['shortname'] }
+    assert_not_includes shortnames, 'ohd'
+  end
+
+  test 'should exclude umbrella project when include_umbrella is false' do
+    get list_projects_path(locale: 'en', format: :json), params: { all: true, include_umbrella: 'false' }
+    assert_response :success
+
+    data = JSON.parse(response.body)
+    shortnames = data.fetch('data', []).map { |project| project['shortname'] }
+    assert_not_includes shortnames, 'ohd'
+  end
+
+  test 'should include umbrella project when include_umbrella is true' do
+    get list_projects_path(locale: 'en', format: :json), params: { all: true, include_umbrella: 'true' }
+    assert_response :success
+
+    data = JSON.parse(response.body)
+    shortnames = data.fetch('data', []).map { |project| project['shortname'] }
+    assert_includes shortnames, 'ohd'
+  end
+
   test 'should hide unshared projects in index all mode for anonymous users' do
     reset!
     host! 'test.portal.oral-history.localhost:47001'


### PR DESCRIPTION
Adds a parameter to projects/list endpoint to optionally include umbrella project (ohd). By default excludes it. 

This fixes the error that ohd was visible in the catalog.