### PR TITLE
fix: fetch missing project data on account page

### DIFF
--- a/app/javascript/modules/auth/AuthShow.js
+++ b/app/javascript/modules/auth/AuthShow.js
@@ -3,6 +3,30 @@ import PropTypes from 'prop-types';
 
 import { useAuthorization } from './authorization-hook';
 
+/**
+ * Conditionally renders children based on authentication state, project access,
+ * catalog mode, and restricted-interview permission checks.
+ *
+ * @param {Object} props
+ * @param {boolean} props.isLoggedIn Real auth state from account/session store.
+ * @param {boolean} props.ifLoggedIn Enables the "logged-in access" branch.
+ * This branch still requires project-level access conditions (admin, project
+ * grant flags, or granted user_project access) and restricted interview
+ * permission when applicable.
+ * @param {boolean} props.ifLoggedOut Enables the "logged-out" branch. In
+ * current logic this also allows rendering for logged-in users on restricted
+ * interviews when they do not have permission.
+ * @param {boolean} props.ifNoProject Enables rendering for logged-in users who
+ * are not admins and do not currently have project access.
+ * @param {boolean} props.ifCatalog Enables rendering for catalog projects.
+ * @param {Object|null} props.user Current user object used for project and
+ * interview permission checks.
+ * @param {Object|null} props.interview Optional interview context used for
+ * restricted visibility checks.
+ * @param {import('react').ReactNode} props.children Content to render when any
+ * enabled branch conditions pass.
+ * @returns {import('react').ReactNode|null}
+ */
 export default function AuthShow({
     isLoggedIn,
     ifLoggedIn,
@@ -15,31 +39,34 @@ export default function AuthShow({
 }) {
     const { project } = useProject();
     const { isAuthorized } = useAuthorization();
-    const isRestricted = interview?.workflow_state === 'restricted';
-    const isCatalog = project?.is_catalog_project;
-    const hasPermission =
+    const isInterviewRestricted = interview?.workflow_state === 'restricted';
+    const isCatalogProject = project?.is_catalog_project;
+    const canViewInterview =
         isAuthorized(interview, 'show') ||
         user?.interview_permissions?.some(
             (perm) => perm.interview_id === interview?.id
         );
+    const hasGrantedProjectAccess = Object.values(
+        user?.user_projects || {}
+    ).find(
+        (userProject) =>
+            userProject?.project_id === project?.id &&
+            userProject?.workflow_state === 'project_access_granted'
+    );
 
     if (
         // logged in and registered for the current project
-        (((isRestricted && hasPermission) || !isRestricted) &&
+        (((isInterviewRestricted && canViewInterview) ||
+            !isInterviewRestricted) &&
             isLoggedIn &&
             ifLoggedIn &&
             user &&
             (user.admin ||
-                (!project.is_ohd &&
-                    (project.grant_access_without_login ||
-                        project.grant_project_access_instantly)) ||
-                Object.values(user.user_projects).find(
-                    (urp) =>
-                        urp.project_id === project?.id &&
-                        urp.workflow_state === 'project_access_granted'
-                ))) ||
+                project?.grant_access_without_login ||
+                project?.grant_project_access_instantly ||
+                hasGrantedProjectAccess)) ||
         // catalog-project
-        (ifCatalog && isCatalog)
+        (ifCatalog && isCatalogProject)
     ) {
         return children;
     } else if (
@@ -51,13 +78,12 @@ export default function AuthShow({
             user &&
             !user.admin &&
             !project?.grant_project_access_instantly &&
-            !project.grant_access_without_login &&
-            !Object.values(user.user_projects).find(
-                (urp) =>
-                    urp.project_id === project?.id &&
-                    urp.workflow_state === 'project_access_granted'
-            )) ||
-        (isLoggedIn && ifLoggedOut && isRestricted && !hasPermission)
+            !project?.grant_access_without_login &&
+            !hasGrantedProjectAccess) ||
+        (isLoggedIn &&
+            ifLoggedOut &&
+            isInterviewRestricted &&
+            !canViewInterview)
     ) {
         // logged out or still not registered for a project
         return children;

--- a/app/javascript/modules/auth/AuthShow.test.js
+++ b/app/javascript/modules/auth/AuthShow.test.js
@@ -1,0 +1,192 @@
+import { useProject } from 'modules/routes';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import AuthShow from './AuthShow';
+import { useAuthorization } from './authorization-hook';
+
+jest.mock('modules/routes', () => ({
+    useProject: jest.fn(),
+}));
+
+jest.mock('./authorization-hook', () => ({
+    useAuthorization: jest.fn(),
+}));
+
+function renderAuthShow(overrides = {}) {
+    const props = {
+        isLoggedIn: false,
+        ifLoggedIn: false,
+        ifLoggedOut: false,
+        ifNoProject: false,
+        ifCatalog: false,
+        user: null,
+        interview: null,
+        children: <span>VISIBLE</span>,
+        ...overrides,
+    };
+
+    return renderToStaticMarkup(<AuthShow {...props} />);
+}
+
+function buildProject(overrides = {}) {
+    return {
+        id: 1,
+        shortname: 'project',
+        is_ohd: false,
+        is_catalog_project: false,
+        grant_access_without_login: false,
+        grant_project_access_instantly: false,
+        ...overrides,
+    };
+}
+
+function buildUser(overrides = {}) {
+    return {
+        admin: false,
+        user_projects: {},
+        interview_permissions: [],
+        ...overrides,
+    };
+}
+
+describe('AuthShow', () => {
+    beforeEach(() => {
+        useProject.mockReturnValue({ project: buildProject() });
+        useAuthorization.mockReturnValue({
+            isAuthorized: jest.fn(() => false),
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders children for logged in users with explicit project_access_granted', () => {
+        useProject.mockReturnValue({
+            project: buildProject({ id: 42 }),
+        });
+
+        const user = buildUser({
+            user_projects: {
+                a: { project_id: 42, workflow_state: 'project_access_granted' },
+            },
+        });
+
+        const html = renderAuthShow({
+            isLoggedIn: true,
+            ifLoggedIn: true,
+            user,
+        });
+
+        expect(html).toContain('VISIBLE');
+    });
+
+    it('renders children for logged out users when ifLoggedOut is set', () => {
+        const html = renderAuthShow({
+            isLoggedIn: false,
+            ifLoggedOut: true,
+            user: null,
+        });
+
+        expect(html).toContain('VISIBLE');
+    });
+
+    it('renders children for logged in users without project access when ifNoProject is set', () => {
+        const user = buildUser({ user_projects: {} });
+
+        const html = renderAuthShow({
+            isLoggedIn: true,
+            ifNoProject: true,
+            user,
+        });
+
+        expect(html).toContain('VISIBLE');
+    });
+
+    it('renders children for catalog projects when ifCatalog is set', () => {
+        useProject.mockReturnValue({
+            project: buildProject({ is_catalog_project: true }),
+        });
+
+        const html = renderAuthShow({
+            ifCatalog: true,
+        });
+
+        expect(html).toContain('VISIBLE');
+    });
+
+    it('renders children for logged in OHD users when grant_access_without_login is true', () => {
+        useProject.mockReturnValue({
+            project: buildProject({
+                id: 21894749,
+                shortname: 'ohd',
+                is_ohd: true,
+                grant_access_without_login: true,
+            }),
+        });
+
+        const html = renderAuthShow({
+            isLoggedIn: true,
+            ifLoggedIn: true,
+            user: buildUser(),
+        });
+
+        expect(html).toContain('VISIBLE');
+    });
+
+    it('renders fallback children for denied restricted interviews when ifLoggedOut is enabled', () => {
+        const user = buildUser({ interview_permissions: [] });
+
+        const html = renderAuthShow({
+            isLoggedIn: true,
+            ifLoggedOut: true,
+            user,
+            interview: { id: 7, workflow_state: 'restricted' },
+        });
+
+        expect(html).toContain('VISIBLE');
+    });
+
+    it('returns null for logged out users when ifLoggedOut is not set', () => {
+        const html = renderAuthShow({
+            isLoggedIn: false,
+            ifLoggedOut: false,
+            user: null,
+        });
+
+        expect(html).toBe('');
+    });
+
+    it('returns null for logged in users without access when only ifLoggedIn is set', () => {
+        const html = renderAuthShow({
+            isLoggedIn: true,
+            ifLoggedIn: true,
+            user: buildUser({ user_projects: {} }),
+        });
+
+        expect(html).toBe('');
+    });
+
+    it('returns null for non-catalog projects when only ifCatalog is set', () => {
+        useProject.mockReturnValue({
+            project: buildProject({ is_catalog_project: false }),
+        });
+
+        const html = renderAuthShow({
+            ifCatalog: true,
+        });
+
+        expect(html).toBe('');
+    });
+
+    it('returns null for restricted interviews in ifLoggedIn mode when user lacks permission', () => {
+        const html = renderAuthShow({
+            isLoggedIn: true,
+            ifLoggedIn: true,
+            user: buildUser({ interview_permissions: [] }),
+            interview: { id: 7, workflow_state: 'restricted' },
+        });
+
+        expect(html).toBe('');
+    });
+});

--- a/app/javascript/modules/user/components/AccountPage.js
+++ b/app/javascript/modules/user/components/AccountPage.js
@@ -35,29 +35,31 @@ export default function AccountPage() {
                     <div className="account-page-header">
                         <h1 className="Page-main-title">{t('account_page')}</h1>
 
-                        <div className="edit-account-icon">
-                            <Modal
-                                title={t('edit.user.edit')}
-                                trigger={
-                                    <FaPencilAlt className="Icon Icon--primary" />
-                                }
-                            >
-                                {(close) => (
-                                    <UserDetailsFormContainer
-                                        onSubmit={close}
-                                        onCancel={close}
-                                    />
-                                )}
-                            </Modal>
-                        </div>
-                        <div className="edit-account-icon">
+                        <div className="account-actions">
+                            <div className="account-actions-icon edit-account-icon">
+                                <Modal
+                                    title={t('edit.user.edit')}
+                                    trigger={
+                                        <FaPencilAlt className="Icon Icon--primary" />
+                                    }
+                                >
+                                    {(close) => (
+                                        <UserDetailsFormContainer
+                                            onSubmit={close}
+                                            onCancel={close}
+                                        />
+                                    )}
+                                </Modal>
+                            </div>
                             {user?.otp_required_for_login && (
-                                <TwoFAPopup showDialogInitially={false} />
+                                <div className="account-actions-icon two-fa-icon">
+                                    <TwoFAPopup showDialogInitially={false} />
+                                </div>
                             )}
-                        </div>
-                        <div className="edit-account-icon">
                             {user?.passkey_required_for_login && (
-                                <PasskeyPopup showDialogInitially={false} />
+                                <div className="account-actions-icon passkey-icon">
+                                    <PasskeyPopup showDialogInitially={false} />
+                                </div>
                             )}
                         </div>
                     </div>

--- a/app/javascript/modules/user/components/PasskeyPopup.js
+++ b/app/javascript/modules/user/components/PasskeyPopup.js
@@ -1,3 +1,4 @@
+/* global railsMode */
 import { useRef } from 'react';
 
 import { OHD_DOMAINS } from 'modules/constants';
@@ -5,6 +6,7 @@ import { getCurrentUser } from 'modules/data';
 import { HelpText } from 'modules/help-text';
 import { useI18n } from 'modules/i18n';
 import { Modal } from 'modules/ui';
+import PropTypes from 'prop-types';
 import { FaKey } from 'react-icons/fa';
 import { useSelector } from 'react-redux';
 
@@ -31,7 +33,7 @@ export default function PasskeyPopup({ showDialogInitially = true }) {
     return (
         <Modal
             key="passkeys-popup"
-            triggerClassName="Button Button--transparent Button--withoutPadding Button--primaryColor"
+            triggerClassName="Button Button--transparent Button--primaryColor"
             title={t('passkey.title')}
             showDialogInitially={showDialogInitially}
             hideButton={showDialogInitially}
@@ -54,6 +56,7 @@ export default function PasskeyPopup({ showDialogInitially = true }) {
                             frameBorder="0"
                             allow={`publickey-credentials-create ${OHD_DOMAINS[railsMode]};
                                 publickey-credentials-get ${OHD_DOMAINS[railsMode]}`}
+                            title={t('passkey.title')}
                         />
                     </>
                 );
@@ -61,3 +64,7 @@ export default function PasskeyPopup({ showDialogInitially = true }) {
         </Modal>
     );
 }
+
+PasskeyPopup.propTypes = {
+    showDialogInitially: PropTypes.bool,
+};

--- a/app/javascript/modules/user/components/TwoFAPopup.js
+++ b/app/javascript/modules/user/components/TwoFAPopup.js
@@ -3,6 +3,7 @@ import { HelpText } from 'modules/help-text';
 import { useI18n } from 'modules/i18n';
 import { Modal } from 'modules/ui';
 import { CancelButton } from 'modules/ui';
+import PropTypes from 'prop-types';
 import { FaQrcode } from 'react-icons/fa';
 import { useSelector } from 'react-redux';
 
@@ -15,7 +16,7 @@ export default function TwoFAPopup({ showDialogInitially = true }) {
     return (
         <Modal
             key="after-enable-2fa-popup"
-            triggerClassName="Button Button--transparent Button--withoutPadding Button--primaryColor"
+            triggerClassName="Button Button--transparent Button--primaryColor"
             title={t('after_enable_2fa.title')}
             showDialogInitially={showDialogInitially}
             hideButton={showDialogInitially}
@@ -33,6 +34,7 @@ export default function TwoFAPopup({ showDialogInitially = true }) {
                         <img
                             src={`data:image/svg+xml;utf8,${encodeURIComponent(user.otp_qrcode)}`}
                             className="u-mr-auto u-ml-auto u-mb-2 u-block u-width-third"
+                            alt={t('after_enable_2fa.text')}
                         />
                     </p>
                     <CancelButton
@@ -44,3 +46,7 @@ export default function TwoFAPopup({ showDialogInitially = true }) {
         </Modal>
     );
 }
+
+TwoFAPopup.propTypes = {
+    showDialogInitially: PropTypes.bool,
+};

--- a/app/javascript/modules/user/components/UserProjects.js
+++ b/app/javascript/modules/user/components/UserProjects.js
@@ -1,15 +1,66 @@
+import { useEffect } from 'react';
+
 import groupBy from 'lodash.groupby';
-import { getCurrentProject, getCurrentUser } from 'modules/data';
-import { useSelector } from 'react-redux';
+import {
+    fetchData,
+    getCurrentProject,
+    getCurrentUser,
+    getProjects,
+    getProjectsStatus,
+} from 'modules/data';
+import { useI18n } from 'modules/i18n';
+import { useDispatch, useSelector } from 'react-redux';
 
 import UserProject from './UserProject';
 
 function UserProjects() {
+    const dispatch = useDispatch();
+    const { locale } = useI18n();
     const user = useSelector(getCurrentUser);
     const currentProject = useSelector(getCurrentProject);
-    const currentUserProject = Object.values(user.user_projects).find(
+    const projects = useSelector(getProjects);
+    const projectsStatus = useSelector(getProjectsStatus);
+    const userProjects = Object.values(user?.user_projects || {});
+
+    const currentUserProject = userProjects.find(
         (urp) => urp.project_id === currentProject?.id
     );
+
+    // TODO: Remove this component-level fetch once project loading is unified.
+    // On non-OHD reloads, Redux often starts with only current project + OHD.
+    // UserProject needs projects[userProject.project_id], so we hydrate missing
+    // projects referenced by user.user_projects here as a temporary bridge.
+    useEffect(() => {
+        if (!currentProject) {
+            return;
+        }
+
+        userProjects.forEach((userProject) => {
+            const projectId = userProject?.project_id;
+
+            if (
+                projectId &&
+                !projects[projectId] &&
+                // Prevent duplicate requests while the same project is in flight.
+                !/^fetching/.test(projectsStatus[projectId] || '')
+            ) {
+                dispatch(
+                    fetchData(
+                        { locale, project: currentProject },
+                        'projects',
+                        projectId
+                    )
+                );
+            }
+        });
+    }, [
+        currentProject,
+        dispatch,
+        locale,
+        projects,
+        projectsStatus,
+        userProjects,
+    ]);
 
     const roles = user?.user_roles && Object.values(user.user_roles);
     const groupedRoles = groupBy(roles, 'project_id');
@@ -31,6 +82,7 @@ function UserProjects() {
 
     return (
         <>
+            {/* Show current project first for stable ordering on account page. */}
             {currentProject && currentUserProject && (
                 <UserProject
                     key={currentProject.id}
@@ -43,7 +95,8 @@ function UserProjects() {
                     supervisedTasks={groupedSupervisedTasks[currentProject.id]}
                 />
             )}
-            {Object.values(user.user_projects).map((urp) => {
+            {/* Render remaining project memberships after the current project. */}
+            {userProjects.map((urp) => {
                 if (urp.project_id !== currentProject?.id) {
                     return (
                         <UserProject

--- a/app/javascript/stylesheets/modules/_user.scss
+++ b/app/javascript/stylesheets/modules/_user.scss
@@ -1,12 +1,21 @@
 div.account-page {
   div.account-page-header {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 1rem;
+    margin-bottom: $base-unit;
 
-    .edit-account-icon {
-      cursor: pointer;
-      margin: 2rem 0 11px 0;
+    h1 {
+      margin: 0;
+    }
+
+    .account-actions {
+      display: flex;
+      gap: 0.5rem;
+
+      .account-actions-icon {
+        cursor: pointer;
+      }
     }
   }
 


### PR DESCRIPTION
Account page didn't correctly display all projects the user has access to, when not all projects are loaded. This fixes the problem by fetching the missing data. Also fixes the error that account page remained white on ohd if `grant_access_without_login` was activated.