### PR TITLE
fix: improve transcript bookmark performance

### DIFF
--- a/app/javascript/modules/transcript/Transcript.jsx
+++ b/app/javascript/modules/transcript/Transcript.jsx
@@ -17,8 +17,16 @@ import { useProject } from 'modules/routes';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { EditableSegment, TranscriptSkeleton } from './components';
-import { useProcessedSegments, useSegmentEditing } from './hooks';
+import {
+    BookmarkSegmentModal,
+    EditableSegment,
+    TranscriptSkeleton,
+} from './components';
+import {
+    useProcessedSegments,
+    useSegmentEditing,
+    useTranscriptBookmarks,
+} from './hooks';
 import { getContributorInformation, isRtlLanguage } from './utils';
 
 export default function Transcript({
@@ -44,6 +52,12 @@ export default function Transcript({
         useInterviewContributors(interview?.id);
     const hasTranscript =
         interview?.alpha3s_with_transcript?.indexOf(transcriptLocale) > -1;
+    const {
+        bookmarkedSegmentIds,
+        selectedBookmarkSegment,
+        handleBookmarkCreate,
+        handleBookmarkModalClose,
+    } = useTranscriptBookmarks();
 
     const segmentEditing = useSegmentEditing();
     const { editingSegmentId } = segmentEditing;
@@ -131,10 +145,20 @@ export default function Transcript({
                             segmentEditing={segmentEditing}
                             prevSegmentTimecode={prevSegment?.timecode}
                             nextSegmentTimecode={nextSegment?.timecode}
+                            hasBookmarks={bookmarkedSegmentIds.has(segment.id)}
+                            onBookmarkCreate={handleBookmarkCreate}
                         />
                     );
                 })}
             </div>
+            {selectedBookmarkSegment && (
+                <BookmarkSegmentModal
+                    segment={selectedBookmarkSegment}
+                    hideButton
+                    showDialogInitially
+                    onClose={handleBookmarkModalClose}
+                />
+            )}
         </>
     );
 }

--- a/app/javascript/modules/transcript/components/BookmarkSegmentModal.jsx
+++ b/app/javascript/modules/transcript/components/BookmarkSegmentModal.jsx
@@ -1,37 +1,34 @@
-import classNames from 'classnames';
 import { getCurrentInterview } from 'modules/data';
 import { useI18n } from 'modules/i18n';
 import { Modal } from 'modules/ui';
-import { WorkbookItemForm, useWorkbook } from 'modules/workbook';
+import { WorkbookItemForm } from 'modules/workbook';
 import PropTypes from 'prop-types';
 import { FaStar } from 'react-icons/fa';
 import { useSelector } from 'react-redux';
-
-import { getSegmentWorkbookAnnotations } from '../utils';
 
 export default function BookmarkSegmentModal({
     segment,
     trigger,
     triggerClassName,
+    showDialogInitially,
+    hideButton,
+    onClose,
 }) {
     const { t } = useI18n();
     const interview = useSelector(getCurrentInterview);
-    const { savedSegments } = useWorkbook();
-
-    const hasBookmarks =
-        getSegmentWorkbookAnnotations(savedSegments, segment.id).length > 0;
 
     // Default to star trigger if not provided
     const defaultTrigger = <FaStar className="Icon Icon--unobtrusive" />;
-    const defaultTriggerClassName = classNames('Button--hover', {
-        'Segment-hiddenButton': !hasBookmarks,
-    });
+    const defaultTriggerClassName = 'Button--hover';
 
     return (
         <Modal
             title={t('save_user_annotation')}
             trigger={trigger || defaultTrigger}
             triggerClassName={triggerClassName || defaultTriggerClassName}
+            showDialogInitially={showDialogInitially}
+            hideButton={hideButton}
+            onClose={onClose}
         >
             {(closeModal) => (
                 <WorkbookItemForm
@@ -62,4 +59,13 @@ BookmarkSegmentModal.propTypes = {
     segment: PropTypes.object.isRequired,
     trigger: PropTypes.node,
     triggerClassName: PropTypes.string,
+    showDialogInitially: PropTypes.bool,
+    hideButton: PropTypes.bool,
+    onClose: PropTypes.func,
+};
+
+BookmarkSegmentModal.defaultProps = {
+    showDialogInitially: false,
+    hideButton: false,
+    onClose: null,
 };

--- a/app/javascript/modules/transcript/components/BookmarkSegmentModal.jsx
+++ b/app/javascript/modules/transcript/components/BookmarkSegmentModal.jsx
@@ -10,9 +10,9 @@ export default function BookmarkSegmentModal({
     segment,
     trigger,
     triggerClassName,
-    showDialogInitially,
-    hideButton,
-    onClose,
+    showDialogInitially = false,
+    hideButton = false,
+    onClose = null,
 }) {
     const { t } = useI18n();
     const interview = useSelector(getCurrentInterview);
@@ -62,10 +62,4 @@ BookmarkSegmentModal.propTypes = {
     showDialogInitially: PropTypes.bool,
     hideButton: PropTypes.bool,
     onClose: PropTypes.func,
-};
-
-BookmarkSegmentModal.defaultProps = {
-    showDialogInitially: false,
-    hideButton: false,
-    onClose: null,
 };

--- a/app/javascript/modules/transcript/components/EditableSegment.jsx
+++ b/app/javascript/modules/transcript/components/EditableSegment.jsx
@@ -47,6 +47,8 @@ function EditableSegment({
     isEditingSegment,
     prevSegmentTimecode,
     nextSegmentTimecode,
+    hasBookmarks,
+    onBookmarkCreate,
 }) {
     const divEl = useRef();
     const { segment: segmentParam } = useTranscriptQueryString();
@@ -321,8 +323,10 @@ function EditableSegment({
                 contentLocale={contentLocale}
                 onEditStart={handleEditStart}
                 onViewContentType={handleToggleContentDisplay}
+                onBookmarkCreate={onBookmarkCreate}
                 isEditingSegment={isEditingSegment}
                 canEditSegment={canEditSegment}
+                hasBookmarks={hasBookmarks}
             />
         </div>
     );
@@ -348,6 +352,8 @@ EditableSegment.propTypes = {
     isEditingSegment: PropTypes.bool,
     prevSegmentTimecode: PropTypes.string,
     nextSegmentTimecode: PropTypes.string,
+    hasBookmarks: PropTypes.bool,
+    onBookmarkCreate: PropTypes.func,
 };
 
 const MemoizedSegment = memo(EditableSegment);

--- a/app/javascript/modules/transcript/components/SegmentButtons.jsx
+++ b/app/javascript/modules/transcript/components/SegmentButtons.jsx
@@ -2,7 +2,6 @@ import { memo } from 'react';
 
 import classNames from 'classnames';
 import { useI18n } from 'modules/i18n';
-import { useWorkbook } from 'modules/workbook';
 import PropTypes from 'prop-types';
 import {
     FaHeading,
@@ -12,27 +11,25 @@ import {
     FaTag,
 } from 'react-icons/fa';
 
-import { BookmarkSegmentModal } from '.';
-import { getSegmentAnnotations, getSegmentWorkbookAnnotations } from '../utils';
+import { getSegmentAnnotations } from '../utils';
 
 function SegmentButtons({
     segment,
     contentLocale,
     onEditStart,
     onViewContentType,
+    onBookmarkCreate,
     isEditingSegment,
     canEditSegment,
+    hasBookmarks,
 }) {
     const { t } = useI18n();
-    const { savedSegments } = useWorkbook();
 
     const hasHeadings = segment.has_heading;
 
     // Annotations are tied to the content locales
     const hasAnnotations =
         getSegmentAnnotations(segment, contentLocale).length > 0;
-    const hasBookmarks =
-        getSegmentWorkbookAnnotations(savedSegments, segment.id).length > 0;
     const hasReferences = (segment.registry_references_count || 0) > 0;
 
     const showEditButton = canEditSegment;
@@ -44,8 +41,10 @@ function SegmentButtons({
         if (hasBookmarks) {
             // If bookmarks exist, show the viewer
             onViewContentType?.('bookmarks');
+            return;
         }
-        // If no bookmarks, opening modal is handled by BookmarkSegmentModal
+
+        onBookmarkCreate?.(segment);
     };
 
     const handleEditClick = () => {
@@ -91,19 +90,29 @@ function SegmentButtons({
                 className={classNames('Segment-buttons')}
                 data-testid="segment-buttons"
             >
-                {hasBookmarks ? (
-                    <button
-                        type="button"
-                        className="Button Button--transparent Button--icon"
-                        title={t('modules.workbook.bookmarks')}
-                        onClick={handleBookmarkClick}
-                        data-testid="segment-button-bookmarks"
-                    >
-                        <FaStar className="Icon Icon--primary" />
-                    </button>
-                ) : (
-                    <BookmarkSegmentModal segment={segment} />
-                )}
+                <button
+                    type="button"
+                    className={classNames(
+                        'Button Button--transparent Button--icon',
+                        {
+                            'Segment-hiddenButton Button--hover': !hasBookmarks,
+                        }
+                    )}
+                    title={t(
+                        hasBookmarks
+                            ? 'modules.workbook.bookmarks'
+                            : 'save_user_annotation'
+                    )}
+                    onClick={handleBookmarkClick}
+                    data-testid="segment-button-bookmarks"
+                >
+                    <FaStar
+                        className={classNames(
+                            'Icon',
+                            hasBookmarks ? 'Icon--primary' : 'Icon--unobtrusive'
+                        )}
+                    />
+                </button>
                 {showEditButton && (
                     <button
                         type="button"
@@ -191,8 +200,10 @@ SegmentButtons.propTypes = {
     contentLocale: PropTypes.string.isRequired,
     onEditStart: PropTypes.func.isRequired,
     onViewContentType: PropTypes.func,
+    onBookmarkCreate: PropTypes.func,
     isEditingSegment: PropTypes.bool,
     canEditSegment: PropTypes.bool,
+    hasBookmarks: PropTypes.bool,
 };
 
 export default memo(SegmentButtons);

--- a/app/javascript/modules/transcript/components/SegmentButtons.test.jsx
+++ b/app/javascript/modules/transcript/components/SegmentButtons.test.jsx
@@ -1,0 +1,102 @@
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import Enzyme, { mount } from 'enzyme';
+
+import SegmentButtons from './SegmentButtons';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+jest.mock('modules/i18n', () => ({
+    useI18n: () => ({
+        t: (key) => key,
+    }),
+}));
+
+describe('SegmentButtons', () => {
+    const baseSegment = {
+        id: 123,
+        has_heading: false,
+        registry_references_count: 0,
+        annotations: {},
+    };
+
+    function renderComponent(props = {}) {
+        return mount(
+            <SegmentButtons
+                segment={baseSegment}
+                contentLocale="en"
+                onEditStart={jest.fn()}
+                onViewContentType={jest.fn()}
+                onBookmarkCreate={jest.fn()}
+                isEditingSegment={false}
+                canEditSegment={false}
+                hasBookmarks={false}
+                {...props}
+            />
+        );
+    }
+
+    it('opens bookmarks viewer when bookmark exists', () => {
+        const onViewContentType = jest.fn();
+        const onBookmarkCreate = jest.fn();
+        const wrapper = renderComponent({
+            hasBookmarks: true,
+            onViewContentType,
+            onBookmarkCreate,
+        });
+
+        wrapper
+            .find('[data-testid="segment-button-bookmarks"]')
+            .simulate('click');
+
+        expect(onViewContentType).toHaveBeenCalledWith('bookmarks');
+        expect(onBookmarkCreate).not.toHaveBeenCalled();
+        wrapper.unmount();
+    });
+
+    it('opens create-bookmark flow when no bookmark exists', () => {
+        const onViewContentType = jest.fn();
+        const onBookmarkCreate = jest.fn();
+        const wrapper = renderComponent({
+            hasBookmarks: false,
+            onViewContentType,
+            onBookmarkCreate,
+        });
+
+        wrapper
+            .find('[data-testid="segment-button-bookmarks"]')
+            .simulate('click');
+
+        expect(onBookmarkCreate).toHaveBeenCalledWith(baseSegment);
+        expect(onViewContentType).not.toHaveBeenCalled();
+        wrapper.unmount();
+    });
+
+    it('does not render bookmark modal component in row buttons', () => {
+        const wrapper = renderComponent({ hasBookmarks: false });
+
+        expect(wrapper.find('BookmarkSegmentModal')).toHaveLength(0);
+        wrapper.unmount();
+    });
+
+    it('hides unbookmarked star by default', () => {
+        const wrapper = renderComponent({ hasBookmarks: false });
+
+        expect(
+            wrapper
+                .find('[data-testid="segment-button-bookmarks"]')
+                .hasClass('Segment-hiddenButton')
+        ).toBe(true);
+        wrapper.unmount();
+    });
+
+    it('keeps bookmarked star visible', () => {
+        const wrapper = renderComponent({ hasBookmarks: true });
+
+        expect(
+            wrapper
+                .find('[data-testid="segment-button-bookmarks"]')
+                .hasClass('Segment-hiddenButton')
+        ).toBe(false);
+        wrapper.unmount();
+    });
+});

--- a/app/javascript/modules/transcript/hooks/index.js
+++ b/app/javascript/modules/transcript/hooks/index.js
@@ -8,3 +8,4 @@ export * from './useSegmentInteraction';
 export * from './useSegmentPreview';
 export * from './useSegmentSaveNotification';
 export * from './useSegmentTabs';
+export * from './useTranscriptBookmarks';

--- a/app/javascript/modules/transcript/hooks/useSegmentEditing.js
+++ b/app/javascript/modules/transcript/hooks/useSegmentEditing.js
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { togglePlayerWidth } from 'modules/media-player';
 
@@ -108,18 +108,31 @@ export function useSegmentEditing() {
         return true;
     }, [handleUnsavedChangesAttempt]);
 
-    return {
-        editingSegmentId,
-        setEditingSegmentId,
-        editingSegmentHasUnsavedChanges,
-        setEditingSegmentHasUnsavedChanges,
-        showUnsavedWarning,
-        setShowUnsavedWarning,
-        dismissUnsavedWarning,
-        continueAfterUnsavedWarning,
-        editingSegmentIdRef,
-        handleUnsavedChangesAttempt,
-        handleEditStart,
-        handleEditEnd,
-    };
+    return useMemo(
+        () => ({
+            editingSegmentId,
+            setEditingSegmentId,
+            editingSegmentHasUnsavedChanges,
+            setEditingSegmentHasUnsavedChanges,
+            showUnsavedWarning,
+            setShowUnsavedWarning,
+            dismissUnsavedWarning,
+            continueAfterUnsavedWarning,
+            editingSegmentIdRef,
+            handleUnsavedChangesAttempt,
+            handleEditStart,
+            handleEditEnd,
+        }),
+        [
+            editingSegmentId,
+            editingSegmentHasUnsavedChanges,
+            showUnsavedWarning,
+            dismissUnsavedWarning,
+            continueAfterUnsavedWarning,
+            editingSegmentIdRef,
+            handleUnsavedChangesAttempt,
+            handleEditStart,
+            handleEditEnd,
+        ]
+    );
 }

--- a/app/javascript/modules/transcript/hooks/useTranscriptBookmarks.js
+++ b/app/javascript/modules/transcript/hooks/useTranscriptBookmarks.js
@@ -1,0 +1,44 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { useWorkbook } from 'modules/workbook';
+
+export function useTranscriptBookmarks() {
+    const { savedSegments } = useWorkbook();
+    const [selectedBookmarkSegment, setSelectedBookmarkSegment] =
+        useState(null);
+
+    const bookmarkedSegmentIds = useMemo(
+        () =>
+            new Set(
+                (savedSegments || [])
+                    .filter(
+                        (annotation) => annotation.reference_type === 'Segment'
+                    )
+                    .map((annotation) => annotation.reference_id)
+            ),
+        [savedSegments]
+    );
+
+    const handleBookmarkCreate = useCallback((segment) => {
+        setSelectedBookmarkSegment(segment);
+    }, []);
+
+    const handleBookmarkModalClose = useCallback(() => {
+        setSelectedBookmarkSegment(null);
+    }, []);
+
+    return useMemo(
+        () => ({
+            bookmarkedSegmentIds,
+            selectedBookmarkSegment,
+            handleBookmarkCreate,
+            handleBookmarkModalClose,
+        }),
+        [
+            bookmarkedSegmentIds,
+            selectedBookmarkSegment,
+            handleBookmarkCreate,
+            handleBookmarkModalClose,
+        ]
+    );
+}

--- a/app/javascript/modules/transcript/hooks/useTranscriptBookmarks.test.js
+++ b/app/javascript/modules/transcript/hooks/useTranscriptBookmarks.test.js
@@ -1,0 +1,107 @@
+import React from 'react';
+
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import Enzyme, { mount } from 'enzyme';
+import PropTypes from 'prop-types';
+import { act } from 'react-dom/test-utils';
+
+import { useTranscriptBookmarks } from './useTranscriptBookmarks';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+jest.mock('modules/workbook', () => ({
+    useWorkbook: jest.fn(),
+}));
+
+const { useWorkbook } = jest.requireMock('modules/workbook');
+
+function HookHarness(props) {
+    return <InnerHarness {...props} />;
+}
+
+function InnerHarness({ onRender }) {
+    const hook = useTranscriptBookmarks();
+
+    React.useEffect(() => {
+        onRender(hook);
+    }, [hook, onRender]);
+
+    return null;
+}
+
+InnerHarness.propTypes = {
+    onRender: PropTypes.func.isRequired,
+};
+
+describe('useTranscriptBookmarks', () => {
+    let wrapper;
+    let hook;
+
+    const render = () => {
+        wrapper = mount(
+            <HookHarness
+                onRender={(h) => {
+                    hook = h;
+                }}
+            />
+        );
+    };
+
+    beforeEach(() => {
+        useWorkbook.mockReturnValue({ savedSegments: [] });
+    });
+
+    afterEach(() => {
+        if (wrapper) wrapper.unmount();
+        hook = null;
+        useWorkbook.mockReset();
+    });
+
+    it('builds bookmarked segment ids from workbook annotations', () => {
+        useWorkbook.mockReturnValue({
+            savedSegments: [
+                {
+                    id: 1,
+                    reference_type: 'Segment',
+                    reference_id: 10,
+                },
+                {
+                    id: 2,
+                    reference_type: 'InterviewReference',
+                    reference_id: 999,
+                },
+                {
+                    id: 3,
+                    reference_type: 'Segment',
+                    reference_id: 20,
+                },
+            ],
+        });
+
+        render();
+
+        expect(hook.bookmarkedSegmentIds.has(10)).toBe(true);
+        expect(hook.bookmarkedSegmentIds.has(20)).toBe(true);
+        expect(hook.bookmarkedSegmentIds.has(999)).toBe(false);
+    });
+
+    it('opens and closes selected bookmark segment', () => {
+        render();
+
+        const segment = { id: 77 };
+
+        act(() => {
+            hook.handleBookmarkCreate(segment);
+        });
+        wrapper.update();
+
+        expect(hook.selectedBookmarkSegment).toEqual(segment);
+
+        act(() => {
+            hook.handleBookmarkModalClose();
+        });
+        wrapper.update();
+
+        expect(hook.selectedBookmarkSegment).toBeNull();
+    });
+});


### PR DESCRIPTION
Rendering large interviews had massive performance issues. One major reason was that each segment row performed its own bookmark/workbook work: subscribing to workbook data, scanning annotations, and often mounting bookmark-modal-related UI per segment. With hundreds or thousands of segments, that multiplied into heavy main-thread scripting, large memory growth, and UI stalls during scroll and interaction.

Solution: Move bookmark state and derived segment-id set into a dedicated transcript hook, remove per-row workbook/modal overhead in segment buttons, and keep a single shared bookmark modal flow.