### PR TITLE
fix: implement interview_date_for_pdf method to correctly show dates in pdf export

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,3 @@
 # Methods added to this helper will be available to all templates in the application.
 module ApplicationHelper
-  def latex_escape(text)
-    LatexToPdf.escape_latex(text)
-  end
 end

--- a/app/helpers/latex_helper.rb
+++ b/app/helpers/latex_helper.rb
@@ -1,5 +1,59 @@
 module LatexHelper
 
+  def latex_escape(text)
+    LatexToPdf.escape_latex(text)
+  end
+
+  def interview_metadata_label_for_pdf(interview, attribute, locale)
+    metadata_field = interview
+      &.project
+      &.metadata_fields
+      &.find_by(source: 'Interview', name: attribute.to_s)
+    custom_label = metadata_field&.label(locale)
+
+    if custom_label.present?
+      custom_label
+    else
+      TranslationValue.for("activerecord.attributes.interview.#{attribute}", locale)
+    end
+  end
+
+  def interview_date_for_pdf(interview_date, separator: ', ')
+    value = interview_date.to_s.strip
+    return value if value.blank?
+
+    # Only normalize when the entire string is made of supported date tokens
+    # and separators; otherwise keep original text as entered.
+    tokenized = value.dup
+    dates = []
+
+    # Collect YYYY-MM-DD dates not adjacent to digits, removing them from the tokenized text.
+    tokenized.gsub!(/(?<!\d)(\d{4})-(\d{1,2})-(\d{1,2})(?!\d)/) do
+      dates << Date.new(Regexp.last_match(1).to_i, Regexp.last_match(2).to_i, Regexp.last_match(3).to_i)
+      ''
+    rescue ArgumentError
+      return value
+    end
+
+    # Collect DD.MM.YYYY dates not adjacent to digits, removing them from the tokenized text.
+    tokenized.gsub!(/(?<!\d)(\d{1,2})\.(\d{1,2})\.(\d{4})(?!\d)/) do
+      dates << Date.new(Regexp.last_match(3).to_i, Regexp.last_match(2).to_i, Regexp.last_match(1).to_i)
+      ''
+    rescue ArgumentError
+      return value
+    end
+
+    remaining = tokenized.gsub(/\s+/, '') # Remove whitespace for separator check
+    separators_only = remaining.gsub(/,|;|\//, '').empty? # Check if only supported separators remain
+
+    # If there are valid dates and the remaining text only contains separators,
+    # format the dates; otherwise return original value.
+    return value unless dates.any? && separators_only
+
+    # Normalize only clean date lists, preserving free-form text unchanged.
+    dates.map { |d| d.strftime('%d.%m.%Y') }.join(separator)
+  end
+
   def latex_speaker(segment, speaker_id, rtl, header_locale)
     if speaker_id != segment.speaker_id && segment.speaking_person.present?
       speaker_id = segment.speaker_id

--- a/app/javascript/modules/data/utils/index.js
+++ b/app/javascript/modules/data/utils/index.js
@@ -1,3 +1,4 @@
 export * from './humanReadable';
 export * from './isDate';
+export * from './parseDate';
 export * from './toDateString';

--- a/app/javascript/modules/data/utils/isDate.js
+++ b/app/javascript/modules/data/utils/isDate.js
@@ -1,22 +1,6 @@
+import { parseDate } from './parseDate';
+
 export function isDate(dateString) {
-    if (typeof dateString !== 'string') {
-        return false;
-    }
-
-    const trimmedDate = dateString.trim();
-
-    return (
-        isFullISO8601Format(trimmedDate) && isValidDate(new Date(trimmedDate))
-    );
-}
-
-export function isFullISO8601Format(dateString) {
-    const format = /^\d{4}-\d{2}-\d{2}$/;
-    return format.test(dateString);
-}
-
-export function isValidDate(date) {
+    const date = parseDate(dateString);
     return date instanceof Date && !isNaN(date);
 }
-
-export default isDate;

--- a/app/javascript/modules/data/utils/isDate.test.js
+++ b/app/javascript/modules/data/utils/isDate.test.js
@@ -18,8 +18,26 @@ test('returns false for dates that are not full', () => {
     expect(actual).toEqual(expected);
 });
 
+test('returns true for German-style dates', () => {
+    const actual = isDate('12.2.2019');
+    const expected = true;
+    expect(actual).toEqual(expected);
+});
+
+test('returns true for US-style dates', () => {
+    const actual = isDate('2/12/2019');
+    const expected = true;
+    expect(actual).toEqual(expected);
+});
+
 test('returns false for invalid dates', () => {
     const actual = isDate('2019-24-40');
+    const expected = false;
+    expect(actual).toEqual(expected);
+});
+
+test('returns false for non-date strings', () => {
+    const actual = isDate('First: 13.2.2026, Second: 14.2.2026');
     const expected = false;
     expect(actual).toEqual(expected);
 });

--- a/app/javascript/modules/data/utils/parseDate.js
+++ b/app/javascript/modules/data/utils/parseDate.js
@@ -1,0 +1,56 @@
+export function parseDate(value) {
+    if (typeof value !== 'string') {
+        return value;
+    }
+
+    const input = value.trim();
+
+    const patterns = [
+        // 2026-2-13 or 2026-02-13
+        {
+            regex: /^(\d{4})-(\d{1,2})-(\d{1,2})$/,
+            order: ['year', 'month', 'day'],
+        },
+
+        // 13.2.2026 or 13.02.2026
+        {
+            regex: /^(\d{1,2})\.(\d{1,2})\.(\d{4})$/,
+            order: ['day', 'month', 'year'],
+        },
+
+        // 2/13/2026, 02/13/2026, 2/3/2026
+        {
+            regex: /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/,
+            order: ['month', 'day', 'year'],
+        },
+    ];
+
+    for (const { regex, order } of patterns) {
+        const match = input.match(regex);
+
+        if (!match) {
+            continue;
+        }
+
+        const parts = {};
+
+        order.forEach((key, index) => {
+            parts[key] = Number(match[index + 1]);
+        });
+
+        const date = new Date(parts.year, parts.month - 1, parts.day);
+
+        // Reject invalid dates like 2026-02-31.
+        if (
+            date.getFullYear() === parts.year &&
+            date.getMonth() === parts.month - 1 && // Months are 0-indexed
+            date.getDate() === parts.day
+        ) {
+            return date;
+        }
+
+        return input;
+    }
+
+    return input;
+}

--- a/app/javascript/modules/data/utils/parseDate.test.js
+++ b/app/javascript/modules/data/utils/parseDate.test.js
@@ -1,0 +1,114 @@
+import { parseDate } from './parseDate';
+
+describe('parseDate', () => {
+    it('parses ISO dates in YYYY-MM-DD format', () => {
+        const result = parseDate('2026-02-13');
+
+        expect(result).toBeInstanceOf(Date);
+        expect(result.getFullYear()).toBe(2026);
+        expect(result.getMonth()).toBe(1); // February, zero-based
+        expect(result.getDate()).toBe(13);
+    });
+
+    it('parses German-style dates in DD.MM.YYYY format', () => {
+        const result = parseDate('13.02.2026');
+
+        expect(result).toBeInstanceOf(Date);
+        expect(result.getFullYear()).toBe(2026);
+        expect(result.getMonth()).toBe(1);
+        expect(result.getDate()).toBe(13);
+    });
+
+    it('parses US-style dates in MM/DD/YYYY format', () => {
+        const result = parseDate('02/13/2026');
+
+        expect(result).toBeInstanceOf(Date);
+        expect(result.getFullYear()).toBe(2026);
+        expect(result.getMonth()).toBe(1);
+        expect(result.getDate()).toBe(13);
+    });
+
+    it('parses dates when month/day do not use leading zeros', () => {
+        const isoResult = parseDate('2026-2-3');
+        const germanResult = parseDate('3.2.2026');
+        const usResult = parseDate('2/3/2026');
+
+        [isoResult, germanResult, usResult].forEach((result) => {
+            expect(result).toBeInstanceOf(Date);
+            expect(result.getFullYear()).toBe(2026);
+            expect(result.getMonth()).toBe(1);
+            expect(result.getDate()).toBe(3);
+        });
+    });
+
+    it('returns trimmed original string when the format does not match', () => {
+        expect(parseDate('2026/02/13')).toBe('2026/02/13');
+        expect(parseDate('13-02-2026')).toBe('13-02-2026');
+        expect(parseDate('February 13, 2026')).toBe('February 13, 2026');
+        expect(parseDate(' 2026.02.13 ')).toBe('2026.02.13');
+    });
+
+    it('returns trimmed original string for invalid ISO dates', () => {
+        expect(parseDate('2026-02-31')).toBe('2026-02-31');
+        expect(parseDate(' 2026-13-01 ')).toBe('2026-13-01');
+    });
+
+    it('returns trimmed original string for invalid German-style dates', () => {
+        expect(parseDate('31.02.2026')).toBe('31.02.2026');
+        expect(parseDate(' 31.02.2026 ')).toBe('31.02.2026');
+    });
+
+    it('returns trimmed original string for invalid US-style dates', () => {
+        expect(parseDate('02/31/2026')).toBe('02/31/2026');
+        expect(parseDate(' 02/31/2026 ')).toBe('02/31/2026');
+    });
+
+    it('returns trimmed original string for invalid months', () => {
+        expect(parseDate('2026-13-01')).toBe('2026-13-01');
+        expect(parseDate('01.13.2026')).toBe('01.13.2026');
+        expect(parseDate('13/01/2026')).toBe('13/01/2026');
+        expect(parseDate(' 2026-13-01 ')).toBe('2026-13-01');
+        expect(parseDate(' 01.13.2026 ')).toBe('01.13.2026');
+        expect(parseDate(' 13/01/2026 ')).toBe('13/01/2026');
+    });
+
+    it('returns trimmed original string for invalid days', () => {
+        expect(parseDate('2026-01-32')).toBe('2026-01-32');
+        expect(parseDate('32.01.2026')).toBe('32.01.2026');
+        expect(parseDate('01/32/2026')).toBe('01/32/2026');
+        expect(parseDate(' 2026-01-32 ')).toBe('2026-01-32');
+        expect(parseDate(' 32.01.2026 ')).toBe('32.01.2026');
+        expect(parseDate(' 01/32/2026 ')).toBe('01/32/2026');
+    });
+
+    it('supports leap-year dates', () => {
+        const result = parseDate('2024-02-29');
+
+        expect(result).toBeInstanceOf(Date);
+        expect(result.getFullYear()).toBe(2024);
+        expect(result.getMonth()).toBe(1); // February, zero-based
+        expect(result.getDate()).toBe(29);
+    });
+
+    it('rejects non-leap-year February 29 dates', () => {
+        expect(parseDate('2026-02-29')).toBe('2026-02-29');
+    });
+
+    it('trims whitespace before parsing', () => {
+        const result = parseDate(' 2026-02-13 ');
+
+        expect(result).toBeInstanceOf(Date);
+        expect(result.getFullYear()).toBe(2026);
+        expect(result.getMonth()).toBe(1); // February, zero-based
+        expect(result.getDate()).toBe(13);
+    });
+
+    it('returns non-string values unchanged', () => {
+        expect(parseDate(null)).toBe(null);
+        expect(parseDate(undefined)).toBe(undefined);
+        expect(parseDate(123)).toBe(123);
+
+        const date = new Date(2026, 1, 13);
+        expect(parseDate(date)).toBe(date);
+    });
+});

--- a/app/javascript/modules/data/utils/toDateString.js
+++ b/app/javascript/modules/data/utils/toDateString.js
@@ -1,11 +1,11 @@
-export function toDateString(value, locale) {
-    if (!value) {
-        return '';
-    }
-    const trimmedDate = value.trim();
-    const date = new Date(trimmedDate);
+import { isDate } from './isDate';
+import { parseDate } from './parseDate';
 
-    if (isNaN(date)) return trimmedDate;
+export function toDateString(value, locale) {
+    if (!value) return '';
+
+    const date = parseDate(value);
+    if (!isDate(date)) return date;
 
     return date.toLocaleDateString(localeString(locale));
 }

--- a/app/javascript/modules/data/utils/toDateString.test.js
+++ b/app/javascript/modules/data/utils/toDateString.test.js
@@ -1,13 +1,43 @@
 import toDateString from './toDateString';
 
-test('returns de style date string for de locale', () => {
-    const actual = toDateString('2019-02-12', 'de');
-    const expected = '12.2.2019';
-    expect(actual).toEqual(expected);
+test('returns trimmed original string if it is not a valid date', () => {
+    const actual = [
+        '  invalid-date  ',
+        'invalid-date',
+        'First: 13.2.2026, Second: 14.2.2026',
+    ];
+    const expected = [
+        'invalid-date',
+        'invalid-date',
+        'First: 13.2.2026, Second: 14.2.2026',
+    ];
+    actual.forEach((a, i) =>
+        expect(toDateString(a, 'de')).toEqual(expected[i])
+    );
 });
 
-test('returns en-GB style date string for en locale', () => {
-    const actual = toDateString('2019-02-12', 'en');
+test('returns DE style date string for de locale', () => {
+    const actual = [
+        '2019-02-12',
+        '2019-2-12',
+        '12.02.2019',
+        '12.2.2019',
+        '02/12/2019',
+        '2/12/2019',
+    ];
+    const expected = '12.2.2019';
+    actual.forEach((a) => expect(toDateString(a, 'de')).toEqual(expected));
+});
+
+test('returns en-US style date string for en locale', () => {
+    const actual = [
+        '2019-02-12',
+        '2019-2-12',
+        '12.02.2019',
+        '12.2.2019',
+        '02/12/2019',
+        '2/12/2019',
+    ];
     const expected = '2/12/2019';
-    expect(actual).toEqual(expected);
+    actual.forEach((a) => expect(toDateString(a, 'en')).toEqual(expected));
 });

--- a/app/javascript/modules/interview-metadata/InterviewInfo.js
+++ b/app/javascript/modules/interview-metadata/InterviewInfo.js
@@ -1,4 +1,5 @@
 import { AuthorizedContent } from 'modules/auth';
+import { toDateString } from 'modules/data';
 import { SingleValueWithForm } from 'modules/forms';
 import { useI18n } from 'modules/i18n';
 import { SelectedRegistryReferencesContainer } from 'modules/registry-references';
@@ -32,7 +33,9 @@ export default function InterviewInfo({ interview, languages }) {
             <SingleValueWithForm
                 obj={interview}
                 attribute={'interview_date'}
-                value={interview.interview_date}
+                value={toDateString(interview.interview_date, locale)}
+                editValue={interview.interview_date}
+                help={'help_texts.date_field'}
                 hideEmpty
             />
             <SingleValueWithForm

--- a/app/javascript/modules/person/PersonForm.js
+++ b/app/javascript/modules/person/PersonForm.js
@@ -82,6 +82,7 @@ const formElements = [
     },
     {
         attribute: 'date_of_birth',
+        help: 'help_texts.date_field',
     },
     {
         elementType: 'textarea',

--- a/app/javascript/stylesheets/modules/_form-default.scss
+++ b/app/javascript/stylesheets/modules/_form-default.scss
@@ -102,7 +102,7 @@ form.default {
   .help-block {
     color: $gray-dark;
     font-size: $font-size-medium;
-    line-height: $base-unit;
+    line-height: $line-height-medium;
     margin: 0;
 
     @include screen-l {

--- a/app/views/latex/_header_footer.pdf.erb
+++ b/app/views/latex/_header_footer.pdf.erb
@@ -27,7 +27,8 @@
   interviewee_name = interview && interview.anonymous_title(header_locale.to_sym)
   footer_text = ""
   footer_text += "#{TranslationValue.for("#{doc_type}_footer", header_locale)} #{interviewee_name}" if interview
-  footer_text += ", #{TranslationValue.for('interview', header_locale)} #{interview.archive_id}, #{interview.interview_date && Date.parse(interview.interview_date).strftime("%d.%m.%Y") rescue interview.interview_date}" if interview && interview.interview_date
+  footer_text += ", #{TranslationValue.for('interview', header_locale)} #{interview.archive_id}"
+  footer_text += ", #{interview_metadata_label_for_pdf(interview, :interview_date, header_locale)}: #{interview_date_for_pdf(interview.interview_date, separator: '/')}" if interview && interview.interview_date
   footer_text += ", #{project.name(header_locale)}"
   footer_text += ", Teilsammlung \"Deutsche Seelen\"" if interview && interview.collection && interview.collection.name =~ /Deutsche Seelen/
   footer_text += ", #{project.domain_with_optional_identifier}/#{header_locale}/interviews/#{interview.archive_id}" if interview

--- a/app/views/latex/_info.pdf.erb
+++ b/app/views/latex/_info.pdf.erb
@@ -1,7 +1,7 @@
 <% unless interview.place_of_interview.nil? %>
   \par{<%= latex_escape( "#{TranslationValue.for('place_of_interview', header_locale)}: #{interview.place_of_interview.descriptor(header_locale)}" ) %>}
 <% end %>
-\par{<%= latex_escape( "#{TranslationValue.for('date', header_locale)}: #{Date.parse(interview.interview_date).strftime("%d.%m.%Y") rescue interview.interview_date}" ) %>}
+\par{<%= latex_escape( "#{interview_metadata_label_for_pdf(interview, :interview_date, header_locale)}: #{interview_date_for_pdf(interview.interview_date)}" ) %>}
 \par{<%= latex_escape( "#{TranslationValue.for('language', header_locale)}: #{interview.language.to_s(header_locale)} #{(interview.translated) ? TranslationValue.for('status.translated', header_locale) : ''}" ) %>}
 <% unless interview.duration.nil? %>
   \par{<%= latex_escape( "#{TranslationValue.for('duration', header_locale)}: #{Time.at(interview.duration).utc.strftime("%H:%M:%S")}" ) %>}

--- a/db/migrate/20260604142500_add_date_field_help_translations.rb
+++ b/db/migrate/20260604142500_add_date_field_help_translations.rb
@@ -1,0 +1,32 @@
+class AddDateFieldHelpTranslations < ActiveRecord::Migration[8.0]
+  TRANSLATIONS = {
+    'help_texts.date_field': {
+      de: 'Formate TT.MM.JJJJ, JJJJ-MM-TT und MM/TT/JJJJ werden als Datum erkannt. Andere Eingaben werden als Text behandelt.',
+      en: 'Formats DD.MM.YYYY, YYYY-MM-DD, and MM/DD/YYYY are recognized as dates. Other entries are treated as text.',
+      el: 'Οι μορφές ΗΗ.ΜΜ.ΕΕΕΕ, ΕΕΕΕ-ΜΜ-ΗΗ και ΜΜ/ΗΗ/ΕΕΕΕ αναγνωρίζονται ως ημερομηνίες. Άλλες καταχωρίσεις αντιμετωπίζονται ως κείμενο.',
+      es: 'Los formatos DD.MM.AAAA, AAAA-MM-DD y MM/DD/AAAA se reconocen como fechas. Otras entradas se tratan como texto.',
+      ru: 'Форматы ДД.ММ.ГГГГ, ГГГГ-ММ-ДД и ММ/ДД/ГГГГ распознаются как даты. Другие значения обрабатываются как текст.',
+      uk: 'Формати ДД.ММ.РРРР, РРРР-ММ-ДД і ММ/ДД/РРРР розпізнаються як дати. Інші значення обробляються як текст.',
+      ar: 'تُعرَف التنسيقات DD.MM.YYYY و YYYY-MM-DD و MM/DD/YYYY كتواريخ. وتُعامَل الإدخالات الأخرى كنص.',
+    },
+  }.freeze
+  
+
+  def up
+    TRANSLATIONS.each do |key, translations|
+      tv = TranslationValue.find_or_create_by(key: key)
+
+      translations.each do |locale, value|
+        translation = tv.translations.find_or_initialize_by(locale: locale.to_s)
+        translation.update(value: value)
+      end
+    end
+  end
+
+  def down
+    TRANSLATIONS.keys.each do |key|
+      TranslationValue.where(key: key).destroy_all
+    end
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_12_141200) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_04_142500) do
   create_table "access_configs", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "project_id", null: false
     t.text "organization"

--- a/test/data_helper.rb
+++ b/test/data_helper.rb
@@ -266,19 +266,19 @@ module DataHelper
         project: project,
         interview_languages: [
           InterviewLanguage.new(
-            language: Language.create!(code: 'rus', name: 'Russisch', locale: 'de'),
+            language: Language.find_or_create_by!(code: 'rus') { |language| language.name = 'Russisch' },
             spec: 'primary'
           ),
           InterviewLanguage.new(
-            language: Language.create!(code: 'pol', name: 'Polnisch', locale: 'de'),
+            language: Language.find_or_create_by!(code: 'pol') { |language| language.name = 'Polnisch' },
             spec: 'secondary'
           ),
           InterviewLanguage.new(
-            language: Language.create!(code: 'ger', name: 'Deutsch', locale: 'de'),
+            language: Language.find_or_create_by!(code: 'ger') { |language| language.name = 'Deutsch' },
             spec: 'primary_translation'
           ),
           InterviewLanguage.new(
-            language: Language.create!(code: 'eng', name: 'Englisch', locale: 'de'),
+            language: Language.find_or_create_by!(code: 'eng') { |language| language.name = 'Englisch' },
             spec: 'secondary_translation'
           )
         ],

--- a/test/lib/latex_helper_test.rb
+++ b/test/lib/latex_helper_test.rb
@@ -1,0 +1,72 @@
+require 'test_helper'
+
+class LatexHelperTest < ActiveSupport::TestCase
+  include LatexHelper
+  
+  test 'interview_date_for_pdf keeps multiple valid dates' do
+    value = '03.07.2019,12.07.2019'
+
+    assert_equal '03.07.2019, 12.07.2019', interview_date_for_pdf(value)
+  end
+
+  test 'interview_date_for_pdf falls back to full string for mixed invalid input' do
+    value = '03.sdfd07.2019,12.07.2019sdfdsfds'
+
+    assert_equal value, interview_date_for_pdf(value)
+  end
+
+  test 'interview_date_for_pdf converts iso date to dd.mm.yyyy' do
+    assert_equal '13.05.2023', interview_date_for_pdf('2023-05-13')
+  end
+
+  test 'interview_date_for_pdf keeps free-form year range untouched' do
+    assert_equal '1979-1981', interview_date_for_pdf('1979-1981')
+  end
+
+  test 'interview_date_for_pdf keeps free-form text untouched' do
+    assert_equal 'sometime in 2020', interview_date_for_pdf('sometime in 2020')
+  end
+
+  test 'interview_date_for_pdf correctly handles multiple dates with different separators' do
+    value = '03.07.2019; 12.07.2019/15.08.2019'
+
+    assert_equal '03.07.2019, 12.07.2019, 15.08.2019', interview_date_for_pdf(value)
+  end
+
+  test 'interview_date_for_pdf correctly uses output separator' do
+    value = '03.07.2019; 12.07.2019/15.08.2019'
+
+    assert_equal '03.07.2019 / 12.07.2019 / 15.08.2019', interview_date_for_pdf(value, separator: ' / ')
+  end
+
+  test 'interview_metadata_label_for_pdf uses project metadata label when present' do
+    project = DataHelper.project_with_contribution_types_and_metadata_fields
+    metadata_field = MetadataField.create!(
+      project: project,
+      source: 'Interview',
+      name: 'interview_date',
+      label: 'Interview date'
+    )
+    metadata_field.update!(label: 'Project Interview Date Label', locale: :en)
+
+    interview = DataHelper.interview_with_everything(project)
+
+    assert_equal 'Project Interview Date Label', interview_metadata_label_for_pdf(interview, :interview_date, :en)
+  end
+
+  test 'interview_metadata_label_for_pdf falls back to activerecord translation key' do
+    project = DataHelper.project_with_contribution_types_and_metadata_fields
+    interview = DataHelper.interview_with_everything(project)
+    metadata_field = MetadataField.create!(
+      project: project,
+      source: 'Interview',
+      name: 'interview_date',
+      label: 'Interview date'
+    )
+    metadata_field.update!(label: nil, locale: :en)
+
+    expected = TranslationValue.for('activerecord.attributes.interview.interview_date', :en)
+
+    assert_equal expected, interview_metadata_label_for_pdf(interview, :interview_date, :en)
+  end
+end


### PR DESCRIPTION
This PR fixes how interview dates are rendered in transcript PDF exports.

Previously, date rendering used a single `Date.parse`, which caused incorrect output for multi-date strings or mixed-format values. Now, PDF export uses a dedicated helper that:

- extracts and formats supported dates (DD.MM.YYYY and YYYY-MM-DD)
- correctly handles multiple dates with separators
- preserves the full original string when the input is mixed/invalid (fallback behavior)

The update is applied in both PDF date display locations (info block and footer), and helper tests were added to cover valid multi-date input, custom separators, ISO conversion, and fallback cases.