### PR TITLE
fix(users-admin): handle missing project refs in archive management cell

### DIFF
--- a/app/javascript/modules/admin/UsersAdminPage.js
+++ b/app/javascript/modules/admin/UsersAdminPage.js
@@ -1,20 +1,10 @@
-import { useEffect } from 'react';
-
 import { AuthShowContainer, AuthorizedContent } from 'modules/auth';
 import { useI18n } from 'modules/i18n';
-import { hideSidebar } from 'modules/sidebar';
 import { UserTable } from 'modules/users';
 import { Helmet } from 'react-helmet';
-import { useDispatch } from 'react-redux';
 
 export default function UsersAdminPage() {
     const { t } = useI18n();
-    const dispatch = useDispatch();
-
-    // INTARCH-2924: do not hide sidebar
-    //useEffect(() => {
-    //dispatch(hideSidebar());
-    //}, []);
 
     return (
         <div className="wrapper-content register">

--- a/app/javascript/modules/users/ArchiveManagementInCell.js
+++ b/app/javascript/modules/users/ArchiveManagementInCell.js
@@ -1,10 +1,8 @@
 import { getProjects } from 'modules/data';
-import { useI18n } from 'modules/i18n';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 
 export default function ArchiveManagementInCell({ row }) {
-    const { t } = useI18n();
     const projects = useSelector(getProjects);
     const user = row.original;
 
@@ -12,13 +10,32 @@ export default function ArchiveManagementInCell({ row }) {
         <ul className="DetailList">
             {Object.values(user.user_roles).map((role) => {
                 if (role.name === 'Archivmanagement') {
-                    const project = projects[role.project_id];
+                    const project = projects?.[role.project_id];
+                    if (!project?.shortname) {
+                        console.warn(
+                            '[ArchiveManagementInCell] Missing project for user role',
+                            {
+                                roleId: role.id,
+                                projectId: role.project_id,
+                                userId: user.id,
+                            }
+                        );
+
+                        return (
+                            <li key={role.id} className="DetailList-item">
+                                {`Unknown project (ID: ${role.project_id})`}
+                            </li>
+                        );
+                    }
+
                     return (
-                        <li key={project.id} className="DetailList-item">
+                        <li key={role.id} className="DetailList-item">
                             {project.shortname}
                         </li>
                     );
                 }
+
+                return null;
             })}
         </ul>
     );

--- a/app/javascript/modules/users/ArchiveManagementInCell.test.js
+++ b/app/javascript/modules/users/ArchiveManagementInCell.test.js
@@ -1,0 +1,89 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import ArchiveManagementInCell from './ArchiveManagementInCell';
+
+jest.mock('modules/i18n', () => ({
+    useI18n: () => ({ t: (key) => key }),
+}));
+
+const mockUseSelector = jest.fn();
+
+jest.mock('react-redux', () => {
+    const actual = jest.requireActual('react-redux');
+    return {
+        ...actual,
+        useSelector: (selector) => mockUseSelector(selector),
+    };
+});
+
+describe('<ArchiveManagementInCell />', () => {
+    let warnSpy;
+
+    beforeEach(() => {
+        mockUseSelector.mockReset();
+        warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+    });
+
+    it('shows fallback text for missing project roles and logs a warning', () => {
+        mockUseSelector.mockReturnValue({
+            1: { id: 1, shortname: 'ohd' },
+        });
+
+        const row = {
+            original: {
+                user_roles: {
+                    1: {
+                        id: 1,
+                        name: 'Archivmanagement',
+                        project_id: 1,
+                    },
+                    2: {
+                        id: 2,
+                        name: 'Archivmanagement',
+                        project_id: 999,
+                    },
+                },
+            },
+        };
+
+        const html = renderToStaticMarkup(
+            <ArchiveManagementInCell row={row} />
+        );
+
+        expect(html).toContain('ohd');
+        expect(html).toContain('Unknown project (ID: 999)');
+        expect(warnSpy).toHaveBeenCalledWith(
+            '[ArchiveManagementInCell] Missing project for user role',
+            expect.objectContaining({
+                roleId: 2,
+                projectId: 999,
+            })
+        );
+    });
+
+    it('does not throw when no matching projects are available', () => {
+        mockUseSelector.mockReturnValue({});
+
+        const row = {
+            original: {
+                user_roles: {
+                    3: {
+                        id: 3,
+                        name: 'Archivmanagement',
+                        project_id: 321,
+                    },
+                },
+            },
+        };
+
+        expect(() =>
+            renderToStaticMarkup(<ArchiveManagementInCell row={row} />)
+        ).not.toThrow();
+
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
- prevent crash when an Archivmanagement role points to a project missing from Redux data
- render fallback label "Unknown project (ID: <project_id>)" instead of silently dropping the row
- add console.warn for debugging
- add tests to cover fallback rendering and warning behavior