### PR TITLE
fix(forms): validate live field values instead of stale defaults

### DIFF
--- a/app/javascript/modules/forms/components/input/InputField.jsx
+++ b/app/javascript/modules/forms/components/input/InputField.jsx
@@ -34,7 +34,9 @@ export default function InputField({
 }) {
     const onBlur = useTouchFieldOnBlur(touchField);
 
-    const defaultValue = value || data?.[attribute];
+    // Keep explicit empty-string edits; || would incorrectly fall back to persisted data.
+    const defaultValue = value ?? data?.[attribute];
+
     const [changeFile, setChangeFile] = useState(false);
 
     const onChange = (event) => {

--- a/app/javascript/modules/forms/components/input/Textarea.jsx
+++ b/app/javascript/modules/forms/components/input/Textarea.jsx
@@ -26,7 +26,9 @@ export default function Textarea({
 }) {
     const onBlur = useTouchFieldOnBlur(touchField);
 
-    const defaultValue = value || data?.[attribute];
+    // Keep explicit empty-string edits; || would incorrectly fall back to persisted data.
+    const defaultValue = value ?? data?.[attribute];
+
     // Determine text direction
     const textDir = checkTextDir(defaultValue || '');
 

--- a/app/javascript/modules/forms/hooks/useFormState.js
+++ b/app/javascript/modules/forms/hooks/useFormState.js
@@ -81,10 +81,14 @@ export function useFormState(
                         []
                 )
                 .map((t) => t[element.attribute]);
+
+            // Use current form value first for live validation; fall back to
+            // element default, then persisted data for untouched fields.
             const elementValue =
-                element.value ||
-                values?.[element.attribute] ||
+                values?.[element.attribute] ??
+                element.value ??
                 data?.[element.attribute];
+
             error = element.multiLocale
                 ? !elementValues?.some((value) => element.validate(value))
                 : !(elementValue && element.validate(elementValue));

--- a/app/javascript/modules/forms/hooks/useFormState.test.js
+++ b/app/javascript/modules/forms/hooks/useFormState.test.js
@@ -133,6 +133,69 @@ describe('useFormState', () => {
             },
         ];
 
+        it('uses current edited value for touched-field validation, not stale element fallback', async () => {
+            render({
+                initialValues: {},
+                data: null,
+                elements: [
+                    {
+                        attribute: 'email',
+                        value: 'not-an-email',
+                        validate: (v) =>
+                            typeof v === 'string' && v.includes('@'),
+                    },
+                ],
+                submitStateOptions: {
+                    fetching: false,
+                    hasValidationErrors: false,
+                    submitted: false,
+                    disableIfUnchanged: false,
+                },
+            });
+
+            await act(async () => {
+                hook.updateField('email', 'valid@example.org');
+                hook.touchField('email');
+            });
+            wrapper.update();
+
+            expect(hook.submitButtonState).toEqual({
+                disabled: false,
+                helpText: null,
+            });
+        });
+
+        it('keeps explicit empty edited value invalid even when fallback values exist', async () => {
+            render({
+                initialValues: { title: 'preset title' },
+                data: { title: 'persisted title' },
+                elements: [
+                    {
+                        attribute: 'title',
+                        value: 'preset title',
+                        validate: (v) => Boolean(v),
+                    },
+                ],
+                submitStateOptions: {
+                    fetching: false,
+                    hasValidationErrors: false,
+                    submitted: false,
+                    disableIfUnchanged: false,
+                },
+            });
+
+            await act(async () => {
+                hook.updateField('title', '');
+                hook.touchField('title');
+            });
+            wrapper.update();
+
+            expect(hook.submitButtonState).toEqual({
+                disabled: true,
+                helpText: 'edit.form.fix_validation_errors',
+            });
+        });
+
         it('initially has no errors', () => {
             render({
                 initialValues: { email: 'a@test.com' },

--- a/app/javascript/modules/interview-metadata/InterviewInfo.js
+++ b/app/javascript/modules/interview-metadata/InterviewInfo.js
@@ -74,7 +74,7 @@ export default function InterviewInfo({ interview, languages }) {
             <SingleValueWithForm
                 obj={interview}
                 validate={function (v) {
-                    return /^\d{2}:\d{2}:\d{2}.\d{3}$/.test(v);
+                    return /^\d{2}:\d{2}:\d{2}\.\d{3}$/.test(v);
                 }}
                 attribute={'duration'}
                 individualErrorMsg={'format'}


### PR DESCRIPTION
Prevent persistent “input is not valid” errors by prioritizing current form state during validation and preserving empty-string edits in input and textarea fields.