### PR TITLE
fix(transcript): make timecode validation tape-aware

### DIFF
--- a/app/javascript/modules/transcript/Transcript.jsx
+++ b/app/javascript/modules/transcript/Transcript.jsx
@@ -27,7 +27,11 @@ import {
     useSegmentEditing,
     useTranscriptBookmarks,
 } from './hooks';
-import { getContributorInformation, isRtlLanguage } from './utils';
+import {
+    getContributorInformation,
+    getSegmentTimecodeBounds,
+    isRtlLanguage,
+} from './utils';
 
 export default function Transcript({
     transcriptLocale,
@@ -127,6 +131,12 @@ export default function Transcript({
                 {processedSegments.map((segment, index, array) => {
                     const prevSegment = array[index - 1];
                     const nextSegment = array[index + 1];
+                    const { prevSegmentTimecode, nextSegmentTimecode } =
+                        getSegmentTimecodeBounds(
+                            segment,
+                            prevSegment,
+                            nextSegment
+                        );
                     const isEditingSegment =
                         isEditviewActive && editingSegmentId === segment.id;
 
@@ -143,8 +153,8 @@ export default function Transcript({
                             nextSegmentTape={nextSegment?.tape_nbr}
                             isEditingSegment={isEditingSegment}
                             segmentEditing={segmentEditing}
-                            prevSegmentTimecode={prevSegment?.timecode}
-                            nextSegmentTimecode={nextSegment?.timecode}
+                            prevSegmentTimecode={prevSegmentTimecode}
+                            nextSegmentTimecode={nextSegmentTimecode}
                             hasBookmarks={bookmarkedSegmentIds.has(segment.id)}
                             onBookmarkCreate={handleBookmarkCreate}
                         />

--- a/app/javascript/modules/transcript/utils/getSegmentTimecodeBounds.js
+++ b/app/javascript/modules/transcript/utils/getSegmentTimecodeBounds.js
@@ -1,0 +1,23 @@
+/**
+ * Computes editable timecode bounds for a segment using only neighbors
+ * on the same tape.
+ *
+ * @param {Object|null|undefined} segment - Current segment
+ * @param {Object|null|undefined} prevSegment - Previous segment in rendered list
+ * @param {Object|null|undefined} nextSegment - Next segment in rendered list
+ * @returns {{prevSegmentTimecode: string|undefined, nextSegmentTimecode: string|undefined}}
+ */
+export function getSegmentTimecodeBounds(segment, prevSegment, nextSegment) {
+    const tapeNbr = segment?.tape_nbr;
+
+    return {
+        prevSegmentTimecode:
+            prevSegment?.tape_nbr === tapeNbr
+                ? prevSegment?.timecode
+                : undefined,
+        nextSegmentTimecode:
+            nextSegment?.tape_nbr === tapeNbr
+                ? nextSegment?.timecode
+                : undefined,
+    };
+}

--- a/app/javascript/modules/transcript/utils/getSegmentTimecodeBounds.test.js
+++ b/app/javascript/modules/transcript/utils/getSegmentTimecodeBounds.test.js
@@ -1,0 +1,42 @@
+import { getSegmentTimecodeBounds } from './getSegmentTimecodeBounds';
+
+describe('getSegmentTimecodeBounds', () => {
+    it('uses only same-tape previous and next segment timecodes', () => {
+        const segment = { tape_nbr: 2, timecode: '00:00:35.960' };
+        const prevSegment = { tape_nbr: 2, timecode: '00:00:20.000' };
+        const nextSegment = { tape_nbr: 2, timecode: '00:00:50.000' };
+
+        expect(
+            getSegmentTimecodeBounds(segment, prevSegment, nextSegment)
+        ).toEqual({
+            prevSegmentTimecode: '00:00:20.000',
+            nextSegmentTimecode: '00:00:50.000',
+        });
+    });
+
+    it('returns no previous bound for the first segment of a tape when previous list neighbor is from another tape', () => {
+        const segment = { tape_nbr: 2, timecode: '00:00:35.960' };
+        const prevSegment = { tape_nbr: 1, timecode: '00:46:24.025' };
+        const nextSegment = { tape_nbr: 2, timecode: '00:01:00.000' };
+
+        expect(
+            getSegmentTimecodeBounds(segment, prevSegment, nextSegment)
+        ).toEqual({
+            prevSegmentTimecode: undefined,
+            nextSegmentTimecode: '00:01:00.000',
+        });
+    });
+
+    it('returns no next bound for the last segment of a tape when next list neighbor is from another tape', () => {
+        const segment = { tape_nbr: 1, timecode: '00:46:24.025' };
+        const prevSegment = { tape_nbr: 1, timecode: '00:46:00.000' };
+        const nextSegment = { tape_nbr: 2, timecode: '00:00:35.960' };
+
+        expect(
+            getSegmentTimecodeBounds(segment, prevSegment, nextSegment)
+        ).toEqual({
+            prevSegmentTimecode: '00:46:00.000',
+            nextSegmentTimecode: undefined,
+        });
+    });
+});

--- a/app/javascript/modules/transcript/utils/index.js
+++ b/app/javascript/modules/transcript/utils/index.js
@@ -4,6 +4,7 @@ export * from './filterTranscriptionTags';
 export * from './getContributorInformation';
 export * from './getSegmentAnnotations';
 export * from './getSegmentWorkbookAnnotations';
+export * from './getSegmentTimecodeBounds';
 export * from './getTimecodeHelpText';
 export * from './isRtlLanguage';
 export * from './segmentsForTape';


### PR DESCRIPTION
Timecode validation failed for first segment of a new tape because bounds used came from last segment of preceeding tape.

Fix is to make usage of prevSegment and nextSegment tape-aware to make sure validation only happens inside a tape.