### PR TITLE
fix: load project data on archive page

### DIFF
--- a/app/javascript/modules/admin/Data.js
+++ b/app/javascript/modules/admin/Data.js
@@ -1,5 +1,5 @@
 import { AuthorizedContent } from 'modules/auth';
-import { useSensitiveData } from 'modules/data';
+import { useLoadCompleteProject, useSensitiveData } from 'modules/data';
 import { DeleteItemForm } from 'modules/forms';
 import { useI18n } from 'modules/i18n';
 import { PersonDetails } from 'modules/person';
@@ -14,6 +14,55 @@ import JoinedData from './JoinedData';
 import getDataDisplayName from './getDataDisplayName';
 
 const Item = AdminMenu.Item;
+
+// Special handling for project data to ensure we have all the data needed for the edit form
+// TODO: In the future, when project loading is more consistent across the app using SWR
+// this should be handled better.
+function EditItemContent({
+    open,
+    close,
+    data,
+    scope,
+    form,
+    hideShow,
+    detailsAttributes,
+    optionsScope,
+}) {
+    // Load project data if scope is project and we have a project id, otherwise
+    // use the data we already have (which may be incomplete or different scope)
+    const isProjectScope = scope === 'project';
+    const projectDbId = data?.id;
+    const loadedProject = useLoadCompleteProject(projectDbId, {
+        enabled: isProjectScope && open,
+        fallbackProject: data,
+    });
+    const dataForForm = isProjectScope ? loadedProject || data : data;
+
+    return (
+        <>
+            {hideShow && (
+                <DataDetails
+                    detailsAttributes={detailsAttributes}
+                    data={dataForForm}
+                    scope={scope}
+                    optionsScope={optionsScope}
+                />
+            )}
+            {form(dataForForm, close, close)}
+        </>
+    );
+}
+
+EditItemContent.propTypes = {
+    open: PropTypes.bool,
+    close: PropTypes.func.isRequired,
+    data: PropTypes.object.isRequired,
+    scope: PropTypes.string.isRequired,
+    form: PropTypes.func.isRequired,
+    hideShow: PropTypes.bool,
+    detailsAttributes: PropTypes.array,
+    optionsScope: PropTypes.string,
+};
 
 export default function Data({
     data,
@@ -112,20 +161,17 @@ export default function Data({
                             label={t('edit.default.edit')}
                             dialogTitle={`${displayName} ${t(`edit.${scope}.edit`)}`}
                         >
-                            {(close) => (
-                                <>
-                                    {hideShow && (
-                                        <DataDetails
-                                            detailsAttributes={
-                                                detailsAttributes
-                                            }
-                                            data={data}
-                                            scope={scope}
-                                            optionsScope={optionsScope}
-                                        />
-                                    )}
-                                    {form(data, close, close)}
-                                </>
+                            {(close, open) => (
+                                <EditItemContent
+                                    open={open}
+                                    close={close}
+                                    data={data}
+                                    scope={scope}
+                                    form={form}
+                                    hideShow={hideShow}
+                                    detailsAttributes={detailsAttributes}
+                                    optionsScope={optionsScope}
+                                />
                             )}
                         </Item>
                     )}

--- a/app/javascript/modules/admin/WrappedDataList.js
+++ b/app/javascript/modules/admin/WrappedDataList.js
@@ -37,6 +37,7 @@ export default function WrappedDataList({
     outerScopeId,
     resultPagesCount,
     detailsAttributes,
+    sensitiveAttributes = [],
     joinedData,
     hideEdit,
     hideDelete,
@@ -169,6 +170,7 @@ export default function WrappedDataList({
                         <DataContainer
                             data={data}
                             scope={scope}
+                            sensitiveAttributes={sensitiveAttributes}
                             outerScope={outerScope}
                             outerScopeId={outerScopeId}
                             detailsAttributes={detailsAttributes}
@@ -220,6 +222,7 @@ WrappedDataList.propTypes = {
     sortAttribute: PropTypes.string,
     sortAttributeTranslated: PropTypes.bool,
     detailsAttributes: PropTypes.array,
+    sensitiveAttributes: PropTypes.array,
     form: PropTypes.object,
     initialFormValues: PropTypes.object,
     formElements: PropTypes.array.isRequired,
@@ -232,6 +235,8 @@ WrappedDataList.propTypes = {
     outerScopeId: PropTypes.number,
     query: PropTypes.object,
     dataStatus: PropTypes.object,
+    statuses: PropTypes.object,
+    otherDataToLoad: PropTypes.array,
     resultPagesCount: PropTypes.number,
     hideAdd: PropTypes.bool,
     hideEdit: PropTypes.bool,

--- a/app/javascript/modules/data/hooks/useLoadCompleteProject.js
+++ b/app/javascript/modules/data/hooks/useLoadCompleteProject.js
@@ -1,29 +1,57 @@
-/* global railsMode */
 import { useEffect } from 'react';
 
-import { OHD_DOMAINS } from 'modules/constants';
+import { useI18n } from 'modules/i18n';
+import { useProject } from 'modules/routes';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { fetchData } from '../redux/actions';
-import { getProjectsStatus, getPublicProjects } from '../redux/selectors';
+import { getProjects, getProjectsStatus } from '../redux/selectors';
 
-export const useLoadCompleteProject = (pId) => {
-    const projects = useSelector(getPublicProjects);
+export const useLoadCompleteProject = (
+    projectDbId,
+    { enabled = true, fallbackProject = null } = {}
+) => {
+    const { locale } = useI18n();
+    const { project: currentProject, projectId: currentProjectId } =
+        useProject();
+    const projects = useSelector(getProjects);
     const projectsStatus = useSelector(getProjectsStatus);
-    const ohdDomain = OHD_DOMAINS[railsMode];
-    const ohd = { shortname: 'ohd', archive_domain: ohdDomain };
-    const project = projects.find((p) => p.id === pId);
     const dispatch = useDispatch();
+    const loadedProject = projects?.[projectDbId] || fallbackProject;
 
     useEffect(() => {
-        if (!projectsStatus[pId]) {
+        if (!enabled || !projectDbId) {
+            return;
+        }
+
+        const status = projectsStatus?.[projectDbId];
+        const isFetched = /^fetched/.test(status || '');
+        const isFetching = /^fetching/.test(status || '');
+
+        if (!isFetched && !isFetching) {
             dispatch(
-                fetchData({ locale: 'de', project: ohd }, 'projects', pId)
+                fetchData(
+                    {
+                        locale,
+                        projectId: currentProjectId,
+                        project: currentProject,
+                    },
+                    'projects',
+                    projectDbId
+                )
             );
         }
-    }, [project]);
+    }, [
+        currentProject,
+        currentProjectId,
+        dispatch,
+        enabled,
+        locale,
+        projectDbId,
+        projectsStatus,
+    ]);
 
-    return project;
+    return loadedProject;
 };
 
 export default useLoadCompleteProject;

--- a/app/javascript/modules/person/PersonForm.js
+++ b/app/javascript/modules/person/PersonForm.js
@@ -125,12 +125,12 @@ export default function PersonForm({ data: person, onSubmit, onCancel }) {
                           }
 
                           mutatePeople(async (people) => {
-                              const eventHolder = people.data[person.id];
+                              const eventHolder = people?.data[person.id];
 
                               const updatedPeople = {
                                   ...people,
                                   data: {
-                                      ...people.data,
+                                      ...people?.data,
                                       [person.id]: {
                                           ...eventHolder,
                                           events: eventHolder.events.filter(
@@ -189,7 +189,7 @@ export default function PersonForm({ data: person, onSubmit, onCancel }) {
                         const updatedPeople = {
                             ...people,
                             data: {
-                                ...people.data,
+                                ...people?.data,
                                 [updatedPerson.id]: updatedPerson,
                             },
                         };

--- a/app/javascript/modules/routes/LinkOrA.js
+++ b/app/javascript/modules/routes/LinkOrA.js
@@ -1,6 +1,8 @@
+/* global railsMode */
 import { getLocale, getProjectId, setProjectId } from 'modules/archive';
 import { OHD_DOMAINS } from 'modules/constants';
 import { getCurrentUser } from 'modules/data';
+import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 
@@ -17,6 +19,16 @@ function LinkOrA({
     const currentProjectId = useSelector(getProjectId);
     const currentAccount = useSelector(getCurrentUser);
     const dispatch = useDispatch();
+
+    // If the project doesn't exist in the store, render children without a link to prevent crashes
+    // As soon as the project data is available, this component will re-render with the correct link
+    if (!project) {
+        return (
+            <span className={className} style={style}>
+                {children}
+            </span>
+        );
+    }
 
     const onOHD = OHD_DOMAINS[railsMode] === window.location.origin;
     const projectHasOtherDomain =
@@ -69,3 +81,16 @@ function LinkOrA({
 }
 
 export default LinkOrA;
+
+LinkOrA.propTypes = {
+    to: PropTypes.string,
+    className: PropTypes.string,
+    style: PropTypes.object,
+    project: PropTypes.shape({
+        shortname: PropTypes.string.isRequired,
+        archive_domain: PropTypes.string,
+    }),
+    children: PropTypes.node.isRequired,
+    onLinkClick: PropTypes.func,
+    params: PropTypes.string,
+};

--- a/app/javascript/modules/ui/AdminMenu.js
+++ b/app/javascript/modules/ui/AdminMenu.js
@@ -100,7 +100,9 @@ function AdminMenuItem({ label, dialogTitle, open, children, onClose }) {
         <Dialog isOpen={open} onDismiss={onClose} className="Modal-dialog">
             <h3 className="Modal-heading">{dialogTitle || label}</h3>
 
-            {typeof children === 'function' ? children(onClose) : children}
+            {typeof children === 'function'
+                ? children(onClose, open)
+                : children}
 
             <button type="button" className="Modal-close" onClick={onClose}>
                 <VisuallyHidden>Close</VisuallyHidden>


### PR DESCRIPTION
When editing projects on `en/projects`, data was not always loaded into redux store. This adds a `EditItemContent` in `Data` to make sure the full project is loaded (when scope is project). Refactors unused `useLoadCompleteProject` to hydrate redux store for the given project.

Also adds some defensive guards to prevent errors if data is not yet available in `PersonForm.js` and `LinkOrA.js`.