### PR TITLE
fix: include collections in catalog search

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -75,10 +75,15 @@ class ProjectsController < ApplicationController
 
     project_ids = projects.map(&:id)
     metrics = ProjectMetricsRepository.new(project_ids)
+    collection_content = CollectionContentRepository.new(
+      project_ids: project_ids,
+      collections_scope: policy_scope(Collection)
+    )
 
     interview_counts = metrics.interview_counts_by_project
     collection_counts = metrics.collection_counts_by_project
     interview_languages_by_project = metrics.interview_languages_by_project
+    collection_preview_by_project = collection_content.preview_by_project
 
     cache_key = [
       'projects-list',
@@ -96,7 +101,13 @@ class ProjectsController < ApplicationController
 
     json = Rails.cache.fetch(cache_key, expires_in: 15.minutes) do
       {
-        data: serialized_projects(projects, interview_counts, collection_counts, interview_languages_by_project),
+        data: serialized_projects(
+          projects,
+          interview_counts,
+          collection_counts,
+          interview_languages_by_project,
+          collection_preview_by_project
+        ),
         page: page,
         result_pages_count: projects.respond_to?(:total_pages) ? projects.total_pages : nil
       }
@@ -275,13 +286,14 @@ class ProjectsController < ApplicationController
       @normalized_include_umbrella = (value.to_s.downcase == 'true')
     end
 
-    def serialized_projects(projects, interview_counts, collection_counts, interview_languages_by_project)
+    def serialized_projects(projects, interview_counts, collection_counts, interview_languages_by_project, collection_preview_by_project)
       ActiveModelSerializers::SerializableResource.new(
         projects,
         each_serializer: ProjectArchiveSerializer,
         interview_counts: interview_counts,
         collection_counts: collection_counts,
-        interview_languages_by_project: interview_languages_by_project
+        interview_languages_by_project: interview_languages_by_project,
+        collection_preview_by_project: collection_preview_by_project
       ).as_json
     end
 

--- a/app/javascript/modules/explorer/components/CollectionList.jsx
+++ b/app/javascript/modules/explorer/components/CollectionList.jsx
@@ -28,6 +28,9 @@ export function CollectionList({ project, query = '' }) {
         sortedCollections.length - INITIAL_VISIBLE_COLLECTIONS,
         0
     );
+    const hiddenByQueryCount = query
+        ? Math.max(collections.length - filteredCollections.length, 0)
+        : 0;
     const visibleCollections = showAllCollections
         ? sortedCollections
         : sortedCollections.slice(0, INITIAL_VISIBLE_COLLECTIONS);
@@ -39,6 +42,14 @@ export function CollectionList({ project, query = '' }) {
                     {t('explorer.collection_list.title', {
                         count: filteredCollections.length,
                     })}
+                    {hiddenByQueryCount > 0 && (
+                        <span className="CollectionList-hiddenByFilterInfo">
+                            {` – ${hiddenByQueryCount} `}
+                            {t('explorer.collection_list.hidden_by_filter', {
+                                count: hiddenByQueryCount,
+                            })}
+                        </span>
+                    )}
                 </p>
                 <CollectionSortControl value={sort} onChange={setSort} />
             </div>

--- a/app/javascript/modules/explorer/components/ProjectCard.jsx
+++ b/app/javascript/modules/explorer/components/ProjectCard.jsx
@@ -115,8 +115,7 @@ export function ProjectCard({ project, query, expanded, onToggle }) {
                         />
                     </div>
 
-                    {/* Don't pass query. we want all related collections */}
-                    <CollectionList project={project} />
+                    <CollectionList project={project} query={query} />
                 </div>
             )}
         </div>

--- a/app/javascript/modules/explorer/utils/filterProjects.js
+++ b/app/javascript/modules/explorer/utils/filterProjects.js
@@ -20,6 +20,17 @@ export const filterProjects = (
     projects.filter((a) => {
         if (query) {
             const lower = query.toLowerCase();
+            const collectionPreview = Array.isArray(a.collection_preview)
+                ? a.collection_preview
+                : a.collection_preview &&
+                    typeof a.collection_preview === 'object'
+                  ? Object.values(a.collection_preview)
+                  : [];
+            const matchesCollections = collectionPreview.some(
+                (collection) =>
+                    collection?.name?.toLowerCase().includes(lower) ||
+                    collection?.notes?.toLowerCase().includes(lower)
+            );
             const matchesText =
                 (a.display_name || a.name)?.toLowerCase().includes(lower) ||
                 a.description?.toLowerCase().includes(lower) ||
@@ -29,7 +40,8 @@ export const filterProjects = (
                         i.name?.toLowerCase().includes(lower) ||
                         i.parent?.name?.toLowerCase().includes(lower) // Include parent institution in text search
                 ) ||
-                a.shortname?.toLowerCase().includes(lower);
+                a.shortname?.toLowerCase().includes(lower) ||
+                matchesCollections;
             if (!matchesText) return false;
         }
 

--- a/app/javascript/modules/explorer/utils/filterProjects.test.js
+++ b/app/javascript/modules/explorer/utils/filterProjects.test.js
@@ -87,6 +87,82 @@ describe('filterProjects', () => {
         expect(byShortname.map((project) => project.id)).toEqual([3]);
     });
 
+    test('filters by text query across collection metadata when present', () => {
+        const withCollectionMetadata = [
+            {
+                ...projects[0],
+                collection_preview: [
+                    { id: 101, name: 'Mountain Memories', notes: '' },
+                ],
+            },
+            {
+                ...projects[1],
+                collection_preview: [
+                    {
+                        id: 202,
+                        name: 'City Life',
+                        notes: 'Stories of migration',
+                    },
+                ],
+            },
+            projects[2],
+        ];
+
+        const byCollectionName = filterProjects(
+            withCollectionMetadata,
+            'mountain memories',
+            null,
+            null,
+            null,
+            null,
+            []
+        );
+
+        const byCollectionNotes = filterProjects(
+            withCollectionMetadata,
+            'migration',
+            null,
+            null,
+            null,
+            null,
+            []
+        );
+
+        expect(byCollectionName.map((project) => project.id)).toEqual([1]);
+        expect(byCollectionNotes.map((project) => project.id)).toEqual([2]);
+    });
+
+    test('handles non-array collection_preview payloads safely', () => {
+        const withInvalidPreviewShapes = [
+            {
+                ...projects[0],
+                collection_preview: true,
+            },
+            {
+                ...projects[1],
+                collection_preview: {
+                    0: {
+                        id: 202,
+                        name: 'City Life',
+                        notes: 'Stories of migration',
+                    },
+                },
+            },
+        ];
+
+        const actual = filterProjects(
+            withInvalidPreviewShapes,
+            'migration',
+            null,
+            null,
+            null,
+            null,
+            []
+        );
+
+        expect(actual.map((project) => project.id)).toEqual([2]);
+    });
+
     test('applies inclusive interview count range', () => {
         const actual = filterProjects(projects, '', 5, 12, null, null, []);
 

--- a/app/javascript/stylesheets/components/_explorer.scss
+++ b/app/javascript/stylesheets/components/_explorer.scss
@@ -307,6 +307,11 @@ h4.CollectionList-collectionsTitle {
   margin: $base-unit 0 $base-unit * 0.5;
 }
 
+.CollectionList-hiddenByFilterInfo {
+  font-weight: normal;
+  color: $gray-darkest;
+}
+
 .CollectionList-showMoreButton {
   display: inline-flex;
   align-items: center;

--- a/app/models/concerns/localized_hash_value.rb
+++ b/app/models/concerns/localized_hash_value.rb
@@ -1,0 +1,38 @@
+module LocalizedHashValue
+  private
+
+  # Returns the best localized value using this fallback chain:
+  # requested locale -> default locale -> first non-blank entry.
+  def localized_hash_value(
+    value,
+    locale: I18n.locale,
+    default_locale: I18n.default_locale,
+    fallback: true
+  )
+    return value unless value.is_a?(Hash)
+
+    value[locale.to_s] || # try current locale as string
+      value[locale.to_sym] || # try current locale as symbol
+      value[default_locale.to_s] || # try default locale as string
+      value[default_locale.to_sym] || # try default locale as symbol
+      (fallback ? value.values.compact.first : nil) # fallback to any available value if enabled
+  end
+
+  def localized_attribute_value(
+    record,
+    attribute_name,
+    locale: I18n.locale,
+    default_locale: I18n.default_locale,
+    fallback: true
+  )
+    localized = record.localized_hash(attribute_name)
+    return nil unless localized
+
+    localized_hash_value(
+      localized,
+      locale: locale,
+      default_locale: default_locale,
+      fallback: fallback
+    )
+  end
+end

--- a/app/repositories/collection_content_repository.rb
+++ b/app/repositories/collection_content_repository.rb
@@ -1,0 +1,39 @@
+class CollectionContentRepository
+  include LocalizedHashValue
+
+  def initialize(project_ids:, collections_scope: Collection.all)
+    @project_ids = Array(project_ids).compact
+    @collections_scope = collections_scope
+  end
+
+  def preview_by_project
+    return {} if @project_ids.blank?
+
+    collections = @collections_scope
+      .where(project_id: @project_ids)
+      .includes(:translations, :project)
+
+    collections.each_with_object({}) do |collection, result|
+      result[collection.project_id] ||= []
+      result[collection.project_id] << preview_entry(collection)
+    end
+  end
+
+  private
+
+  def preview_entry(collection)
+    {
+      id: collection.id,
+      name: localized_value(collection, :name),
+      notes: localized_value(collection, :notes)
+    }
+  end
+
+  def localized_value(record, attribute_name)
+    localized_attribute_value(
+      record,
+      attribute_name,
+      default_locale: record.project&.default_locale || I18n.default_locale
+    )
+  end
+end

--- a/app/serializers/collection_lite_serializer.rb
+++ b/app/serializers/collection_lite_serializer.rb
@@ -1,4 +1,6 @@
 class CollectionLiteSerializer < ActiveModel::Serializer
+  include LocalizedHashValue
+
   attributes :id,
     :project_id,
     :project_name,
@@ -102,19 +104,14 @@ class CollectionLiteSerializer < ActiveModel::Serializer
   private
 
   def localized_value(attribute_name)
-    localized = object.localized_hash(attribute_name)
-    return nil unless localized
-
-    localized[I18n.locale.to_s] ||
-      localized[I18n.locale.to_sym] ||
-      localized.values.compact.first
+    localized_attribute_value(
+      object,
+      attribute_name,
+      default_locale: object.project&.default_locale || I18n.default_locale
+    )
   end
 
   def localized_descriptor(value)
-    return value unless value.is_a?(Hash)
-
-    value[I18n.locale.to_s] ||
-      value[I18n.locale.to_sym] ||
-      value.values.compact.first
+    localized_hash_value(value)
   end
 end

--- a/app/serializers/project_archive_serializer.rb
+++ b/app/serializers/project_archive_serializer.rb
@@ -15,6 +15,7 @@ class ProjectArchiveSerializer < ActiveModel::Serializer
     :workflow_state,
     :languages_ui,
     :languages_interviews,
+    :collection_preview,
     :display_ohd_link,
     :has_map,
     :is_catalog,
@@ -101,6 +102,12 @@ class ProjectArchiveSerializer < ActiveModel::Serializer
 
   def languages_interviews
     source = instance_options[:interview_languages_by_project] || {}
+    source.fetch(object.id, [])
+  end
+
+  # Lightweight collection preview data, used to search for projects and collections
+  def collection_preview
+    source = instance_options[:collection_preview_by_project] || {}
     source.fetch(object.id, [])
   end
 

--- a/app/serializers/project_lite_serializer.rb
+++ b/app/serializers/project_lite_serializer.rb
@@ -1,4 +1,6 @@
 class ProjectLiteSerializer < ProjectArchiveSerializer
+  include LocalizedHashValue
+
   attributes :cooperation_partners,
     :leaders,
     :managers,
@@ -81,12 +83,9 @@ class ProjectLiteSerializer < ProjectArchiveSerializer
   end
 
   def localized_descriptor(value)
-    return value unless value.is_a?(Hash)
-
-    value[I18n.locale.to_s] ||
-      value[I18n.locale.to_sym] ||
-      value[object.default_locale.to_s] ||
-      value[object.default_locale.to_sym] ||
-      value.values.compact.first
+    localized_hash_value(
+      value,
+      default_locale: object.default_locale || I18n.default_locale
+    )
   end
 end

--- a/db/migrate/20260609085100_add_collection_filter_translations.rb
+++ b/db/migrate/20260609085100_add_collection_filter_translations.rb
@@ -1,0 +1,30 @@
+class AddCollectionFilterTranslations < ActiveRecord::Migration[8.0]
+  TRANSLATIONS = {
+    'explorer.collection_list.hidden_by_filter': {
+      de: 'durch Filter ausgeblendet',
+      en: 'hidden by filter',
+      el: 'κρυφό λόγω φίλτρου',
+      es: 'oculto por filtro',
+      ru: 'скрыто фильтром',
+      uk: 'приховано фільтром',
+      ar: 'مخفي بسبب التصفية',
+    },
+  }.freeze
+
+  def up
+    TRANSLATIONS.each do |key, translations|
+      tv = TranslationValue.find_or_create_by(key: key)
+
+      translations.each do |locale, value|
+        translation = tv.translations.find_or_initialize_by(locale: locale.to_s)
+        translation.update(value: value)
+      end
+    end
+  end
+
+  def down
+    TRANSLATIONS.keys.each do |key|
+      TranslationValue.where(key: key).destroy_all
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_12_141200) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_09_085100) do
   create_table "access_configs", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "project_id", null: false
     t.text "organization"

--- a/test/models/concerns/localized_hash_value_test.rb
+++ b/test/models/concerns/localized_hash_value_test.rb
@@ -1,0 +1,82 @@
+require 'test_helper'
+
+class LocalizedHashValueTest < ActiveSupport::TestCase
+  class LocalizedHashValueProbe
+    include LocalizedHashValue
+    # Expose the module's private methods for testing
+    public :localized_hash_value, :localized_attribute_value
+  end
+
+  # Simple fake record class to test localized_attribute_value without 
+  # needing a full ActiveRecord model
+  class FakeLocalizedRecord
+    def initialize(values)
+      @values = values
+    end
+
+    def localized_hash(attribute_name)
+      @values[attribute_name]
+    end
+  end
+
+  # For each test, create a new instance of the probe class that includes the concern
+  setup do
+    @probe = LocalizedHashValueProbe.new
+  end
+
+  test 'localized_hash_value prefers current locale' do
+    value = { 'en' => 'English', 'de' => 'Deutsch' }
+
+    I18n.with_locale(:en) do
+      assert_equal 'English', @probe.localized_hash_value(value)
+    end
+  end
+
+  test 'localized_hash_value falls back to default locale' do
+    value = { 'de' => 'Deutsch' }
+
+    I18n.with_locale(:en) do
+      assert_equal 'Deutsch', @probe.localized_hash_value(value, default_locale: :de)
+    end
+  end
+
+  test 'localized_hash_value falls back to first non-blank entry' do
+    value = { 'es' => nil, 'it' => 'Italiano' }
+
+    I18n.with_locale(:en) do
+      assert_equal 'Italiano', @probe.localized_hash_value(value, default_locale: :de)
+    end
+  end
+
+  test 'localized_hash_value can disable fallback' do
+    value = { 'it' => 'Italiano' }
+
+    I18n.with_locale(:en) do
+      assert_nil @probe.localized_hash_value(value, default_locale: :de, fallback: false)
+    end
+  end
+
+  test 'localized_hash_value returns non-hash values unchanged' do
+    assert_equal 'plain', @probe.localized_hash_value('plain')
+  end
+
+  test 'localized_attribute_value reads localized_hash and applies fallback chain' do
+    record = FakeLocalizedRecord.new(
+      title: { 'de' => 'Titel' }
+    )
+
+    I18n.with_locale(:en) do
+      assert_equal 'Titel', @probe.localized_attribute_value(
+        record,
+        :title,
+        default_locale: :de
+      )
+    end
+  end
+
+  test 'localized_attribute_value returns nil when attribute is missing' do
+    record = FakeLocalizedRecord.new({})
+
+    assert_nil @probe.localized_attribute_value(record, :title)
+  end
+end

--- a/test/repositories/collection_content_repository_test.rb
+++ b/test/repositories/collection_content_repository_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+require 'securerandom'
+
+class CollectionContentRepositoryTest < ActiveSupport::TestCase
+  test 'returns collection preview grouped by project for current locale' do
+    project = DataHelper.test_project(shortname: "cc#{SecureRandom.hex(3)}a")
+
+    institution = Institution.create!(
+      name: 'Content Repository Institution',
+      shortname: "ccinst#{SecureRandom.hex(2)}"
+    )
+    InstitutionProject.create!(project: project, institution: institution)
+
+    collection = Collection.create!(
+      project: project,
+      institution: institution,
+      name: 'Kriegskinder',
+      notes: 'Zeitzeugenberichte'
+    )
+
+    repository = CollectionContentRepository.new(
+      project_ids: [project.id],
+      collections_scope: Collection.all
+    )
+
+    preview = repository.preview_by_project
+
+    assert_equal collection.id, preview[project.id][0][:id]
+    assert_equal 'Kriegskinder', preview[project.id][0][:name]
+    assert_equal 'Zeitzeugenberichte', preview[project.id][0][:notes]
+  end
+end

--- a/test/serializers/project_lite_serializer_test.rb
+++ b/test/serializers/project_lite_serializer_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+require 'ostruct'
+
+class ProjectLiteSerializerTest < ActiveSupport::TestCase
+  test 'localized_descriptor uses helper fallback chain with project default locale' do
+    serializer = ProjectLiteSerializer.new(OpenStruct.new(default_locale: 'de'))
+
+    I18n.with_locale(:en) do
+      value = { 'de' => 'Themen' }
+      assert_equal 'Themen', serializer.send(:localized_descriptor, value)
+    end
+  end
+end


### PR DESCRIPTION
Because project list didn't include data on included collections for each project (except counts), search in the catalog wouldn't match collection title or description. This PR:

- Extracts a concern to provide central methods for `localized_hash_value` and `localized_attribute_value` to avoid code duplication (https://github.com/oral-history-digital/ohd/commit/9394f866e301b4ef2f8ec9c42dd2fbb300f96f47)
- Adds `collection_preview` to project endpoint (https://github.com/oral-history-digital/ohd/commit/d3165801f39f03cc26176b8753a732703c2900a0)
- Uses the newly available data in catalog search (https://github.com/oral-history-digital/ohd/commit/1dfe81e7fffa9c95001c8a6a2cb8465b51937ef2)