### PR TITLE
fix: correctly display user_projects

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -130,7 +130,7 @@ class UsersController < ApplicationController
     users = users.joins(:user_projects).where("user_projects.workflow_state = ?", params[:workflow_state] || 'project_access_requested') if !current_project.is_ohd? && params[:workflow_state] != 'all' && params[:workflow_users_for_project].blank?
     users = users.joins(:user_projects).where("user_projects.project_id = ?", params[:project]) if !params[:project].blank?
 
-    users = users.where(default_locale: params[:default_locale]) if (!params[:default_locale].blank? || params[:default_locale] == 'all')
+    users = users.where(default_locale: params[:default_locale]) if I18n.available_locales.map(&:to_s).include?(params[:default_locale])
     users = users.joins(:user_roles).where("user_roles.role_id = ?", params[:role]) if !params[:role].blank?
 
     # Filter users by MFA status if the 'mfa' parameter is present

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -137,6 +137,17 @@ class UsersController < ApplicationController
     users = users.where("otp_required_for_login = ? OR passkey_required_for_login = ?", true, true) if params[:mfa] == 'enabled'
     users = users.where(otp_required_for_login: [false, nil], passkey_required_for_login: [false, nil]) if params[:mfa] == 'disabled'
 
+    # Filter users by project manager role if the 'project_manager' parameter is present
+    if %w(yes no).include?(params[:project_manager])
+      manager_user_ids = UserRole.
+        joins(role: :translations).
+        where(role_translations: { name: 'Archivmanagement' }).
+        select(:user_id)
+      users = params[:project_manager] == 'yes' ?
+        users.where(id: manager_user_ids) :
+        users.where.not(id: manager_user_ids)
+    end
+
     if !params[:workflow_users_for_project].blank?
       workflowRoleIds = current_project.roles.where(name: %w(Redaktion Qualitätsmanagement Archivmanagement)).map(&:id)
       users = users.joins(:user_roles).where("user_roles.role_id IN (?)", workflowRoleIds)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -133,6 +133,10 @@ class UsersController < ApplicationController
     users = users.where(default_locale: params[:default_locale]) if (!params[:default_locale].blank? || params[:default_locale] == 'all')
     users = users.joins(:user_roles).where("user_roles.role_id = ?", params[:role]) if !params[:role].blank?
 
+    # Filter users by MFA status if the 'mfa' parameter is present
+    users = users.where("otp_required_for_login = ? OR passkey_required_for_login = ?", true, true) if params[:mfa] == 'enabled'
+    users = users.where(otp_required_for_login: [false, nil], passkey_required_for_login: [false, nil]) if params[:mfa] == 'disabled'
+
     if !params[:workflow_users_for_project].blank?
       workflowRoleIds = current_project.roles.where(name: %w(Redaktion Qualitätsmanagement Archivmanagement)).map(&:id)
       users = users.joins(:user_roles).where("user_roles.role_id IN (?)", workflowRoleIds)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -146,7 +146,7 @@ class UsersController < ApplicationController
       total_pages = users.total_pages
     end
 
-    users = users.includes(roles: :permissions).map{|u| UserSerializer.new(u)}
+    users = users.includes(roles: :permissions, user_projects: :project).map{|u| UserSerializer.new(u)}
 
     respond_to do |format|
       format.html { render 'react/app' }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -146,7 +146,11 @@ class UsersController < ApplicationController
       total_pages = users.total_pages
     end
 
-    users = users.includes(roles: :permissions, user_projects: :project).map{|u| UserSerializer.new(u)}
+    users = users.includes(
+      roles: :permissions,
+      user_projects: :project,
+      user_roles: {role: [:translations, :project]}
+    ).map{|u| UserSerializer.new(u)}
 
     respond_to do |format|
       format.html { render 'react/app' }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -137,6 +137,11 @@ class UsersController < ApplicationController
     users = users.where("otp_required_for_login = ? OR passkey_required_for_login = ?", true, true) if params[:mfa] == 'enabled'
     users = users.where(otp_required_for_login: [false, nil], passkey_required_for_login: [false, nil]) if params[:mfa] == 'disabled'
 
+    # Filter users by admin status if the 'superuser' parameter is present and the current user is an admin
+    if current_user&.admin? && %w(yes no).include?(params[:superuser])
+      users = users.where(admin: params[:superuser] == 'yes')
+    end
+
     # Filter users by project manager role if the 'project_manager' parameter is present
     if %w(yes no).include?(params[:project_manager])
       manager_user_ids = UserRole.

--- a/app/javascript/modules/users/ArchiveManagementInCell.js
+++ b/app/javascript/modules/users/ArchiveManagementInCell.js
@@ -2,23 +2,15 @@ import PropTypes from 'prop-types';
 
 export default function ArchiveManagementInCell({ row }) {
     const user = row.original;
-    const userProjectsByProjectId = Object.values(
-        user.user_projects || {}
-    ).reduce((memo, userProject) => {
-        memo[userProject.project_id] = userProject;
-        return memo;
-    }, {});
     const entries = Object.values(user.user_roles)
         .map((role) => {
-            if (role.name !== 'Archivmanagement') {
+            if (!role.archive_management) {
                 return null;
             }
 
-            const userProject = userProjectsByProjectId[role.project_id];
-
-            if (!userProject?.shortname) {
+            if (!role.project_shortname) {
                 console.warn(
-                    '[ArchiveManagementInCell] Missing user project for user role',
+                    '[ArchiveManagementInCell] Missing project for user role',
                     {
                         roleId: role.id,
                         projectId: role.project_id,
@@ -34,8 +26,8 @@ export default function ArchiveManagementInCell({ row }) {
 
             return {
                 id: role.id,
-                label: userProject.shortname,
-                title: `${userProject.name} (ID: ${userProject.project_id})`,
+                label: role.project_shortname,
+                title: `${role.project_name} (ID: ${role.project_id})`,
             };
         })
         .filter(Boolean);

--- a/app/javascript/modules/users/ArchiveManagementInCell.js
+++ b/app/javascript/modules/users/ArchiveManagementInCell.js
@@ -1,43 +1,54 @@
-import { getProjects } from 'modules/data';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
 
 export default function ArchiveManagementInCell({ row }) {
-    const projects = useSelector(getProjects);
     const user = row.original;
+    const userProjectsByProjectId = Object.values(
+        user.user_projects || {}
+    ).reduce((memo, userProject) => {
+        memo[userProject.project_id] = userProject;
+        return memo;
+    }, {});
+    const entries = Object.values(user.user_roles)
+        .map((role) => {
+            if (role.name !== 'Archivmanagement') {
+                return null;
+            }
+
+            const userProject = userProjectsByProjectId[role.project_id];
+
+            if (!userProject?.shortname) {
+                console.warn(
+                    '[ArchiveManagementInCell] Missing user project for user role',
+                    {
+                        roleId: role.id,
+                        projectId: role.project_id,
+                        userId: user.id,
+                    }
+                );
+
+                return {
+                    id: role.id,
+                    label: `Unknown project (ID: ${role.project_id})`,
+                };
+            }
+
+            return {
+                id: role.id,
+                label: userProject.shortname,
+                title: `${userProject.name} (ID: ${userProject.project_id})`,
+            };
+        })
+        .filter(Boolean);
 
     return (
-        <ul className="DetailList">
-            {Object.values(user.user_roles).map((role) => {
-                if (role.name === 'Archivmanagement') {
-                    const project = projects?.[role.project_id];
-                    if (!project?.shortname) {
-                        console.warn(
-                            '[ArchiveManagementInCell] Missing project for user role',
-                            {
-                                roleId: role.id,
-                                projectId: role.project_id,
-                                userId: user.id,
-                            }
-                        );
-
-                        return (
-                            <li key={role.id} className="DetailList-item">
-                                {`Unknown project (ID: ${role.project_id})`}
-                            </li>
-                        );
-                    }
-
-                    return (
-                        <li key={role.id} className="DetailList-item">
-                            {project.shortname}
-                        </li>
-                    );
-                }
-
-                return null;
-            })}
-        </ul>
+        <span>
+            {entries.map((entry, index) => (
+                <span key={entry.id} title={entry.title}>
+                    {index > 0 && ', '}
+                    {entry.label}
+                </span>
+            ))}
+        </span>
     );
 }
 

--- a/app/javascript/modules/users/ArchiveManagementInCell.test.js
+++ b/app/javascript/modules/users/ArchiveManagementInCell.test.js
@@ -2,25 +2,10 @@ import { renderToStaticMarkup } from 'react-dom/server';
 
 import ArchiveManagementInCell from './ArchiveManagementInCell';
 
-jest.mock('modules/i18n', () => ({
-    useI18n: () => ({ t: (key) => key }),
-}));
-
-const mockUseSelector = jest.fn();
-
-jest.mock('react-redux', () => {
-    const actual = jest.requireActual('react-redux');
-    return {
-        ...actual,
-        useSelector: (selector) => mockUseSelector(selector),
-    };
-});
-
 describe('<ArchiveManagementInCell />', () => {
     let warnSpy;
 
     beforeEach(() => {
-        mockUseSelector.mockReset();
         warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     });
 
@@ -28,13 +13,18 @@ describe('<ArchiveManagementInCell />', () => {
         warnSpy.mockRestore();
     });
 
-    it('shows fallback text for missing project roles and logs a warning', () => {
-        mockUseSelector.mockReturnValue({
-            1: { id: 1, shortname: 'ohd' },
-        });
-
+    it('uses user project payload for shortname tooltip and missing project fallback', () => {
         const row = {
             original: {
+                id: 17,
+                user_projects: {
+                    1: {
+                        id: 1,
+                        project_id: 1,
+                        shortname: 'ohd',
+                        name: 'Oral-History.Digital',
+                    },
+                },
                 user_roles: {
                     1: {
                         id: 1,
@@ -55,9 +45,11 @@ describe('<ArchiveManagementInCell />', () => {
         );
 
         expect(html).toContain('ohd');
+        expect(html).toContain('title="Oral-History.Digital (ID: 1)"');
+        expect(html).toContain('>, Unknown project (ID: 999)<');
         expect(html).toContain('Unknown project (ID: 999)');
         expect(warnSpy).toHaveBeenCalledWith(
-            '[ArchiveManagementInCell] Missing project for user role',
+            '[ArchiveManagementInCell] Missing user project for user role',
             expect.objectContaining({
                 roleId: 2,
                 projectId: 999,
@@ -65,11 +57,10 @@ describe('<ArchiveManagementInCell />', () => {
         );
     });
 
-    it('does not throw when no matching projects are available', () => {
-        mockUseSelector.mockReturnValue({});
-
+    it('does not throw when no matching user projects are available', () => {
         const row = {
             original: {
+                user_projects: {},
                 user_roles: {
                     3: {
                         id: 3,

--- a/app/javascript/modules/users/ArchiveManagementInCell.test.js
+++ b/app/javascript/modules/users/ArchiveManagementInCell.test.js
@@ -13,27 +13,23 @@ describe('<ArchiveManagementInCell />', () => {
         warnSpy.mockRestore();
     });
 
-    it('uses user project payload for shortname tooltip and missing project fallback', () => {
+    it('uses user role project payload for shortname tooltip and missing project fallback', () => {
         const row = {
             original: {
                 id: 17,
-                user_projects: {
-                    1: {
-                        id: 1,
-                        project_id: 1,
-                        shortname: 'ohd',
-                        name: 'Oral-History.Digital',
-                    },
-                },
                 user_roles: {
                     1: {
                         id: 1,
-                        name: 'Archivmanagement',
+                        name: 'Archive Manager',
+                        archive_management: true,
                         project_id: 1,
+                        project_shortname: 'ohd',
+                        project_name: 'Oral-History.Digital',
                     },
                     2: {
                         id: 2,
-                        name: 'Archivmanagement',
+                        name: 'Archive Manager',
+                        archive_management: true,
                         project_id: 999,
                     },
                 },
@@ -49,7 +45,7 @@ describe('<ArchiveManagementInCell />', () => {
         expect(html).toContain('>, Unknown project (ID: 999)<');
         expect(html).toContain('Unknown project (ID: 999)');
         expect(warnSpy).toHaveBeenCalledWith(
-            '[ArchiveManagementInCell] Missing user project for user role',
+            '[ArchiveManagementInCell] Missing project for user role',
             expect.objectContaining({
                 roleId: 2,
                 projectId: 999,
@@ -57,14 +53,14 @@ describe('<ArchiveManagementInCell />', () => {
         );
     });
 
-    it('does not throw when no matching user projects are available', () => {
+    it('does not throw when no matching role project payload is available', () => {
         const row = {
             original: {
-                user_projects: {},
                 user_roles: {
                     3: {
                         id: 3,
-                        name: 'Archivmanagement',
+                        name: 'Archive Manager',
+                        archive_management: true,
                         project_id: 321,
                     },
                 },

--- a/app/javascript/modules/users/MfaStatusCell.js
+++ b/app/javascript/modules/users/MfaStatusCell.js
@@ -1,0 +1,35 @@
+import { useI18n } from 'modules/i18n';
+import { formatDate } from 'modules/utils';
+import PropTypes from 'prop-types';
+import { FaUserShield } from 'react-icons/fa';
+
+export default function MfaStatusCell({ row }) {
+    const { t, locale } = useI18n();
+    const user = row.original;
+    const otpDate = formatDate(user.changed_to_otp_at, locale);
+    const passkeyDate = formatDate(user.changed_to_passkey_at, locale);
+    const otpActive = Boolean(user.otp_required_for_login);
+    const passkeyActive = Boolean(user.passkey_required_for_login);
+
+    if (!otpActive && !passkeyActive) {
+        return null;
+    }
+
+    const formatMfaStatus = (label, active, date) => {
+        const status = t(active ? 'enabled' : 'disabled');
+        const timestamp = date ? ` (${date})` : '';
+
+        return `${label}: ${status}${timestamp}`;
+    };
+
+    const title = [
+        formatMfaStatus(t('user.mfa_otp'), otpActive, otpDate),
+        formatMfaStatus(t('user.mfa_passkey'), passkeyActive, passkeyDate),
+    ].join('\n');
+
+    return <FaUserShield title={title} aria-label={title} />;
+}
+
+MfaStatusCell.propTypes = {
+    row: PropTypes.object.isRequired,
+};

--- a/app/javascript/modules/users/MfaStatusCell.test.js
+++ b/app/javascript/modules/users/MfaStatusCell.test.js
@@ -1,0 +1,50 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import MfaStatusCell from './MfaStatusCell';
+
+jest.mock('modules/i18n', () => ({
+    useI18n: () => ({
+        locale: 'en',
+        t: (key) =>
+            ({
+                disabled: 'inactive',
+                enabled: 'active',
+                'user.mfa_otp': 'Authentication app',
+                'user.mfa_passkey': 'Passkey',
+            })[key] || key,
+    }),
+}));
+
+describe('<MfaStatusCell />', () => {
+    it('renders nothing when no MFA method is active', () => {
+        const html = renderToStaticMarkup(
+            <MfaStatusCell
+                row={{
+                    original: {
+                        otp_required_for_login: false,
+                        passkey_required_for_login: false,
+                    },
+                }}
+            />
+        );
+
+        expect(html).toBe('');
+    });
+
+    it('renders a tooltip with both MFA method statuses', () => {
+        const html = renderToStaticMarkup(
+            <MfaStatusCell
+                row={{
+                    original: {
+                        otp_required_for_login: true,
+                        changed_to_otp_at: '2026-06-01',
+                        passkey_required_for_login: false,
+                    },
+                }}
+            />
+        );
+
+        expect(html).toContain('Authentication app: active');
+        expect(html).toContain('Passkey: inactive');
+    });
+});

--- a/app/javascript/modules/users/ProjectAccessGrantedCell.js
+++ b/app/javascript/modules/users/ProjectAccessGrantedCell.js
@@ -4,7 +4,11 @@ export default function ProjectAccessGrantedCell({ row }) {
     const user = row.original;
 
     const count = Object.values(user.user_projects).reduce((n, up) => {
-        return n + (up.workflow_state === 'project_access_granted');
+        return (
+            n +
+            (up.shortname !== 'ohd' &&
+                up.workflow_state === 'project_access_granted')
+        );
     }, 0);
 
     return <p>{count}</p>;

--- a/app/javascript/modules/users/ProjectAccessGrantedCell.js
+++ b/app/javascript/modules/users/ProjectAccessGrantedCell.js
@@ -6,7 +6,8 @@ export default function ProjectAccessGrantedCell({ row }) {
     const count = Object.values(user.user_projects).reduce((n, up) => {
         return (
             n +
-            (up.shortname !== 'ohd' &&
+            (up.shortname &&
+                up.shortname !== 'ohd' &&
                 up.workflow_state === 'project_access_granted')
         );
     }, 0);

--- a/app/javascript/modules/users/ProjectAccessGrantedCell.test.js
+++ b/app/javascript/modules/users/ProjectAccessGrantedCell.test.js
@@ -1,0 +1,34 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import ProjectAccessGrantedCell from './ProjectAccessGrantedCell';
+
+describe('<ProjectAccessGrantedCell />', () => {
+    it('counts granted non-OHD user projects', () => {
+        const row = {
+            original: {
+                user_projects: {
+                    1: {
+                        shortname: 'ohd',
+                        workflow_state: 'project_access_granted',
+                    },
+                    2: {
+                        shortname: 'test',
+                        workflow_state: 'project_access_granted',
+                    },
+                    3: {
+                        shortname: 'pending',
+                        workflow_state: 'project_access_requested',
+                    },
+                    4: {
+                        shortname: 'demo',
+                        workflow_state: 'project_access_granted',
+                    },
+                },
+            },
+        };
+
+        expect(
+            renderToStaticMarkup(<ProjectAccessGrantedCell row={row} />)
+        ).toContain('2');
+    });
+});

--- a/app/javascript/modules/users/ProjectsOverview.js
+++ b/app/javascript/modules/users/ProjectsOverview.js
@@ -1,71 +1,116 @@
-import { useState } from 'react';
-
-import { getProjects } from 'modules/data';
 import { useI18n } from 'modules/i18n';
+import { Disclosure } from 'modules/ui';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
 
 export default function ProjectsOverview({ user }) {
     const { t, locale } = useI18n();
-    const projects = useSelector(getProjects);
-    const userProjects = Object.values(user.user_projects);
+    const userProjects = Object.values(user.user_projects)
+        .filter((userProject) => userProject.shortname !== 'ohd')
+        .sort((a, b) =>
+            `${a.name} ${a.shortname}`.localeCompare(
+                `${b.name} ${b.shortname}`,
+                locale
+            )
+        );
+    const disclosureThreshold = 10;
 
-    const [showProject, setShowProject] = useState('');
+    const capitalizeFirstLetter = (str) =>
+        str ? str.charAt(0).toUpperCase() + str.slice(1) : str;
 
-    const projectDisplay = (userProject) => {
+    const projectGroups = [
+        {
+            title: capitalizeFirstLetter(
+                t('workflow_states.user_projects.project_access_requested')
+            ),
+            projects: userProjects.filter(
+                (userProject) =>
+                    userProject.workflow_state === 'project_access_requested'
+            ),
+        },
+        {
+            title: capitalizeFirstLetter(
+                t('workflow_states.user_projects.project_access_granted')
+            ),
+            projects: userProjects.filter(
+                (userProject) =>
+                    userProject.workflow_state === 'project_access_granted'
+            ),
+        },
+        {
+            title: capitalizeFirstLetter(
+                [
+                    'project_access_rejected',
+                    'project_access_blocked',
+                    'project_access_terminated',
+                ]
+                    .map((key) => t(`workflow_states.user_projects.${key}`))
+                    .join('/')
+            ),
+            projects: userProjects.filter(
+                (userProject) =>
+                    ![
+                        'project_access_requested',
+                        'project_access_granted',
+                    ].includes(userProject.workflow_state)
+            ),
+            showStatus: true,
+        },
+    ].filter((group) => group.projects.length > 0);
+
+    const projectDetails = (userProject, showStatus = false) => {
         const workflowState = t(
             `workflow_states.user_projects.${userProject.workflow_state}`
         );
-        const project = projects[userProject.project_id];
-
-        if (!project || project.is_ohd) {
-            return null;
-        }
-
-        const date = new Date(
+        const dateValue =
             userProject.processed_at ||
-                userProject.activated_at ||
-                userProject.updated_at
-        ).toLocaleDateString(locale, { dateStyle: 'medium' });
+            userProject.activated_at ||
+            userProject.updated_at;
+        const date = dateValue
+            ? new Date(dateValue).toLocaleDateString(locale, {
+                  dateStyle: 'medium',
+              })
+            : null;
+        const details = [showStatus && workflowState, date].filter(Boolean);
+
         return (
             <li key={userProject.id} className="DetailList-item">
-                <h4>
-                    <button
-                        type="button"
-                        className="Button Button--asLink"
-                        onClick={() =>
-                            setShowProject(
-                                showProject === project.shortname
-                                    ? ''
-                                    : project.shortname
-                            )
-                        }
-                    >
-                        {project.shortname}
-                    </button>
-                </h4>
-                <div
-                    className={
-                        showProject === project.shortname ? '' : 'hidden'
-                    }
-                >
-                    <p>
-                        {t('modules.project_access.actual_workflow_state') +
-                            ': ' +
-                            workflowState}
-                    </p>
-                    <p>{t('modules.project_access.at') + ': ' + date}</p>
-                </div>
+                <strong>{userProject.name}</strong> ({userProject.shortname})
+                {details.length > 0 && ` - ${details.join(' - ')}`}
             </li>
+        );
+    };
+
+    const projectList = (projects, showStatus) => (
+        <ul className="DetailList">
+            {projects.map((userProject) =>
+                projectDetails(userProject, showStatus)
+            )}
+        </ul>
+    );
+
+    const projectGroup = (group) => {
+        const list = projectList(group.projects, group.showStatus);
+
+        return (
+            <section key={group.title}>
+                <h4>{group.title}</h4>
+                {group.projects.length > disclosureThreshold ? (
+                    <Disclosure
+                        title={`${group.projects.length} ${t('activerecord.models.project.other')}`}
+                    >
+                        {list}
+                    </Disclosure>
+                ) : (
+                    list
+                )}
+            </section>
         );
     };
 
     return (
         <>
             <h3>{t('modules.project_access.many')}</h3>
-            <ul className="DetailList">
-                {userProjects.map((urp) => projectDisplay(urp))}
-            </ul>
+            {projectGroups.map((group) => projectGroup(group))}
         </>
     );
 }

--- a/app/javascript/modules/users/ProjectsOverview.js
+++ b/app/javascript/modules/users/ProjectsOverview.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 export default function ProjectsOverview({ user }) {
     const { t, locale } = useI18n();
     const userProjects = Object.values(user.user_projects)
+        .filter((userProject) => userProject.shortname)
         .filter((userProject) => userProject.shortname !== 'ohd')
         .sort((a, b) =>
             `${a.name} ${a.shortname}`.localeCompare(

--- a/app/javascript/modules/users/ProjectsOverview.test.js
+++ b/app/javascript/modules/users/ProjectsOverview.test.js
@@ -1,0 +1,94 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import ProjectsOverview from './ProjectsOverview';
+
+jest.mock('modules/i18n', () => ({
+    useI18n: () => ({
+        locale: 'en',
+        t: (key) => key,
+    }),
+}));
+
+const userProject = (
+    id,
+    shortname,
+    name,
+    workflowState = 'project_access_granted'
+) => ({
+    id,
+    project_id: id,
+    shortname,
+    name,
+    workflow_state: workflowState,
+    updated_at: '2026-06-01',
+});
+
+describe('<ProjectsOverview />', () => {
+    it('renders projects grouped by workflow state from user project payload', () => {
+        const html = renderToStaticMarkup(
+            <ProjectsOverview
+                user={{
+                    user_projects: {
+                        1: userProject(1, 'ohd', 'Oral-History.Digital'),
+                        2: userProject(2, 'test', 'Test Project'),
+                        3: userProject(3, 'demo', 'Demo Project'),
+                        4: userProject(
+                            4,
+                            'pending',
+                            'Pending Project',
+                            'project_access_requested'
+                        ),
+                        5: userProject(
+                            5,
+                            'blocked',
+                            'Blocked Project',
+                            'project_access_blocked'
+                        ),
+                    },
+                }}
+            />
+        );
+
+        expect(
+            html.indexOf(
+                'workflow_states.user_projects.project_access_requested'
+            )
+        ).toBeLessThan(
+            html.indexOf('workflow_states.user_projects.project_access_granted')
+        );
+        expect(
+            html.indexOf('workflow_states.user_projects.project_access_granted')
+        ).toBeLessThan(html.indexOf('Other'));
+        expect(html.indexOf('Demo Project (demo)')).toBeLessThan(
+            html.indexOf('Test Project (test)')
+        );
+        expect(html).toContain('Pending Project (pending)');
+        expect(html).toContain('Test Project (test)');
+        expect(html).toContain('Blocked Project (blocked)');
+        expect(html).toContain(
+            'workflow_states.user_projects.project_access_blocked'
+        );
+        expect(html).not.toContain('Oral-History.Digital');
+    });
+
+    it('uses a disclosure for larger groups', () => {
+        const projects = [1, 2, 3, 4, 5, 6].reduce((memo, id) => {
+            memo[id] = userProject(id, `p${id}`, `Project ${id}`);
+            return memo;
+        }, {});
+
+        const html = renderToStaticMarkup(
+            <ProjectsOverview user={{ user_projects: projects }} />
+        );
+
+        expect(html).toContain('Disclosure-toggle');
+        expect(html).toContain('6 activerecord.models.project.other');
+        expect(html.indexOf('Project 1')).toBeLessThan(
+            html.indexOf('Project 6')
+        );
+        expect(html).toContain('Project 1 (p1)');
+        expect(html).toContain(
+            'workflow_states.user_projects.project_access_granted'
+        );
+    });
+});

--- a/app/javascript/modules/users/ProjectsOverview.test.js
+++ b/app/javascript/modules/users/ProjectsOverview.test.js
@@ -49,22 +49,20 @@ describe('<ProjectsOverview />', () => {
             />
         );
 
+        // ProjectsOverview uses capitalizeFirstLetter, that's why we capitalize here, too
         expect(
             html.indexOf(
-                'workflow_states.user_projects.project_access_requested'
+                'Workflow_states.user_projects.project_access_requested'
             )
         ).toBeLessThan(
-            html.indexOf('workflow_states.user_projects.project_access_granted')
+            html.indexOf('Workflow_states.user_projects.project_access_granted')
         );
-        expect(
-            html.indexOf('workflow_states.user_projects.project_access_granted')
-        ).toBeLessThan(html.indexOf('Other'));
-        expect(html.indexOf('Demo Project (demo)')).toBeLessThan(
-            html.indexOf('Test Project (test)')
+        expect(html.indexOf('Demo Project')).toBeLessThan(
+            html.indexOf('Test Project')
         );
-        expect(html).toContain('Pending Project (pending)');
-        expect(html).toContain('Test Project (test)');
-        expect(html).toContain('Blocked Project (blocked)');
+        expect(html).toContain('Pending Project');
+        expect(html).toContain('Test Project');
+        expect(html).toContain('Blocked Project');
         expect(html).toContain(
             'workflow_states.user_projects.project_access_blocked'
         );
@@ -72,23 +70,26 @@ describe('<ProjectsOverview />', () => {
     });
 
     it('uses a disclosure for larger groups', () => {
-        const projects = [1, 2, 3, 4, 5, 6].reduce((memo, id) => {
-            memo[id] = userProject(id, `p${id}`, `Project ${id}`);
-            return memo;
-        }, {});
+        const projects = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].reduce(
+            (memo, id) => {
+                memo[id] = userProject(id, `p${id}`, `Project ${id}`);
+                return memo;
+            },
+            {}
+        );
 
         const html = renderToStaticMarkup(
             <ProjectsOverview user={{ user_projects: projects }} />
         );
 
         expect(html).toContain('Disclosure-toggle');
-        expect(html).toContain('6 activerecord.models.project.other');
+        expect(html).toContain('11 activerecord.models.project.other');
         expect(html.indexOf('Project 1')).toBeLessThan(
-            html.indexOf('Project 6')
+            html.indexOf('Project 11')
         );
-        expect(html).toContain('Project 1 (p1)');
+        expect(html).toContain('Project 1');
         expect(html).toContain(
-            'workflow_states.user_projects.project_access_granted'
+            'Workflow_states.user_projects.project_access_granted' // Capitalized because function capitalizes first letter
         );
     });
 });

--- a/app/javascript/modules/users/UserEdit.js
+++ b/app/javascript/modules/users/UserEdit.js
@@ -1,5 +1,6 @@
 import { getCurrentProject } from 'modules/data';
 import { useI18n } from 'modules/i18n';
+import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 
 import ProjectsOverview from './ProjectsOverview';
@@ -63,37 +64,55 @@ export default function UserEdit({ data, dataPath, onSubmit }) {
 
     const detailRepresentation = (value, detail, index) => {
         return (
-            <p className="detail" key={`${detail}-${data.id}-${index}`}>
-                <span className="name">
+            <p
+                className="UserEdit-detail"
+                key={`${detail}-${data.id}-${index}`}
+            >
+                <span className="UserEdit-detailName">
                     {t(`activerecord.attributes.user.${detail}`) + ': '}
                 </span>
-                <span className="content">{detailValue(value, detail)}</span>
+                <span className="UserEdit-detailContent">
+                    {detailValue(value, detail)}
+                </span>
             </p>
         );
     };
 
     return (
-        <div className="details">
-            <h3>{t('user.registration')}</h3>
-            {details.map((detail, index) => {
-                return detailRepresentation(
-                    data[detail] || userProject?.[detail],
-                    detail,
-                    index
-                );
-            })}
+        <div className="UserEdit details">
+            <section className="UserEdit-section">
+                <h3>{t('user.registration')}</h3>
+                <div className="UserEdit-details">
+                    {details.map((detail, index) => {
+                        return detailRepresentation(
+                            data[detail] || userProject?.[detail],
+                            detail,
+                            index
+                        );
+                    })}
+                </div>
+            </section>
 
-            {!project.is_ohd && <h3>{t('modules.project_access.one')}</h3>}
-            {!project.is_ohd &&
-                projectDetails.map((detail, index) => {
-                    return detailRepresentation(
-                        userProject[detail],
-                        detail,
-                        index
-                    );
-                })}
+            {!project.is_ohd && (
+                <section className="UserEdit-section">
+                    <h3>{t('modules.project_access.one')}</h3>
+                    <div className="UserEdit-details">
+                        {projectDetails.map((detail, index) => {
+                            return detailRepresentation(
+                                userProject[detail],
+                                detail,
+                                index
+                            );
+                        })}
+                    </div>
+                </section>
+            )}
 
-            {project.is_ohd && <ProjectsOverview user={data} />}
+            {project.is_ohd && (
+                <section className="UserEdit-section">
+                    <ProjectsOverview user={data} />
+                </section>
+            )}
 
             <UserFormContainer
                 data={project.is_ohd ? data : userProject}
@@ -105,3 +124,9 @@ export default function UserEdit({ data, dataPath, onSubmit }) {
         </div>
     );
 }
+
+UserEdit.propTypes = {
+    data: PropTypes.object.isRequired,
+    dataPath: PropTypes.string.isRequired,
+    onSubmit: PropTypes.func,
+};

--- a/app/javascript/modules/users/UserTable.js
+++ b/app/javascript/modules/users/UserTable.js
@@ -223,6 +223,7 @@ export default function UserTable() {
                 {data?.total} {t('activerecord.models.user.other')}
             </h1>
             <TableWithPagination
+                className="UserTable"
                 data={data?.data || []}
                 pageCount={data?.result_pages_count}
                 columns={columns}
@@ -237,86 +238,96 @@ export default function UserTable() {
                 manualSort={sorting}
                 changePageSize={false}
             >
-                <SelectField
-                    className="u-mb-small"
-                    values={workflowStateFilterValues}
-                    label={t('activerecord.attributes.user.workflow_state')}
-                    attribute="workflow_state"
-                    optionsScope={`workflow_states.user${project.is_ohd ? '' : '_project'}s`}
-                    handleChange={handleWorkflowStateFilterChange}
-                    withEmpty={false}
-                    keepOrder={true}
-                />
-                {project.available_locales.length > 1 && (
+                <div className="UserTable-filters">
                     <SelectField
-                        className="u-mb-small"
-                        values={localeFilterValues}
-                        label={t('activerecord.attributes.user.default_locale')}
-                        attribute="default_locale"
-                        optionsScope={'default_locales'}
-                        handleChange={handleLocaleFilterChange}
+                        className="UserTable-filter"
+                        values={workflowStateFilterValues}
+                        label={t('activerecord.attributes.user.workflow_state')}
+                        attribute="workflow_state"
+                        optionsScope={`workflow_states.user${project.is_ohd ? '' : '_project'}s`}
+                        handleChange={handleWorkflowStateFilterChange}
                         withEmpty={false}
+                        keepOrder={true}
                     />
-                )}
-                <SelectField
-                    className="u-mb-small"
-                    values={[
-                        { id: 'enabled', name: t('enabled') },
-                        { id: 'disabled', name: t('disabled') },
-                    ]}
-                    label="MFA"
-                    attribute="mfa"
-                    handleChange={handleMfaFilterChange}
-                    withEmpty={true}
-                    keepOrder={true}
-                />
-                {project.is_ohd && (
-                    <>
+                    {project.available_locales.length > 1 && (
                         <SelectField
-                            className="u-mb-small"
-                            values={[
-                                { id: 'yes', name: t('boolean_value.true') },
-                                { id: 'no', name: t('boolean_value.false') },
-                            ]}
+                            className="UserTable-filter"
+                            values={localeFilterValues}
                             label={t(
-                                'modules.project_access.archive_management_in'
+                                'activerecord.attributes.user.default_locale'
                             )}
-                            attribute="project_manager"
-                            handleChange={handleProjectManagerFilterChange}
-                            withEmpty={true}
-                            keepOrder={true}
+                            attribute="default_locale"
+                            optionsScope={'default_locales'}
+                            handleChange={handleLocaleFilterChange}
+                            withEmpty={false}
                         />
-
-                        <SelectField
-                            className="u-mb-small"
-                            values={projects}
-                            label={t('activerecord.models.project.one')}
-                            attribute="project"
-                            handleChange={handleProjectFilterChange}
-                            withEmpty={true}
-                        />
-                    </>
-                )}
-                {!project.is_ohd && (
-                    <Fetch
-                        fetchParams={[
-                            'roles',
-                            null,
-                            null,
-                            `for_projects=${project?.id}`,
+                    )}
+                    <SelectField
+                        className="UserTable-filter"
+                        values={[
+                            { id: 'enabled', name: t('enabled') },
+                            { id: 'disabled', name: t('disabled') },
                         ]}
-                        testSelector={getRolesForCurrentProjectFetched}
-                    >
-                        <SelectField
-                            className="u-mb-small"
-                            values={projectRoles}
-                            label={t('activerecord.models.role.one')}
-                            attribute="role"
-                            handleChange={handleRoleFilterChange}
-                            withEmpty={true}
-                        />
-                    </Fetch>
-                )}
+                        label="MFA"
+                        attribute="mfa"
+                        handleChange={handleMfaFilterChange}
+                        withEmpty={true}
+                        keepOrder={true}
+                    />
+                    {project.is_ohd && (
+                        <>
+                            <SelectField
+                                className="UserTable-filter"
+                                values={[
+                                    {
+                                        id: 'yes',
+                                        name: t('boolean_value.true'),
+                                    },
+                                    {
+                                        id: 'no',
+                                        name: t('boolean_value.false'),
+                                    },
+                                ]}
+                                label={t(
+                                    'modules.project_access.archive_management_in'
+                                )}
+                                attribute="project_manager"
+                                handleChange={handleProjectManagerFilterChange}
+                                withEmpty={true}
+                                keepOrder={true}
+                            />
+
+                            <SelectField
+                                className="UserTable-filter UserTable-filter--wide"
+                                values={projects}
+                                label={t('activerecord.models.project.one')}
+                                attribute="project"
+                                handleChange={handleProjectFilterChange}
+                                withEmpty={true}
+                            />
+                        </>
+                    )}
+                    {!project.is_ohd && (
+                        <Fetch
+                            fetchParams={[
+                                'roles',
+                                null,
+                                null,
+                                `for_projects=${project?.id}`,
+                            ]}
+                            testSelector={getRolesForCurrentProjectFetched}
+                        >
+                            <SelectField
+                                className="UserTable-filter UserTable-filter--wide"
+                                values={projectRoles}
+                                label={t('activerecord.models.role.one')}
+                                attribute="role"
+                                handleChange={handleRoleFilterChange}
+                                withEmpty={true}
+                            />
+                        </Fetch>
+                    )}
+                </div>
             </TableWithPagination>
         </>
     );

--- a/app/javascript/modules/users/UserTable.js
+++ b/app/javascript/modules/users/UserTable.js
@@ -30,22 +30,27 @@ export default function UserTable() {
     const [filter, setFilter] = useState('');
 
     const [projectFilter, setProjectFilter] = useState('');
-    const handleProjectFilterChange = (name, value) => {
+    const handleProjectFilterChange = (_, value) => {
         setProjectFilter(value);
     };
 
     const [roleFilter, setRoleFilter] = useState('');
-    const handleRoleFilterChange = (name, value) => {
+    const handleRoleFilterChange = (_, value) => {
         setRoleFilter(value);
     };
 
     const [mfaFilter, setMfaFilter] = useState('');
-    const handleMfaFilterChange = (name, value) => {
+    const handleMfaFilterChange = (_, value) => {
         setMfaFilter(value);
     };
 
+    const [projectManagerFilter, setProjectManagerFilter] = useState('');
+    const handleProjectManagerFilterChange = (_, value) => {
+        setProjectManagerFilter(value);
+    };
+
     const [localeFilter, setLocaleFilter] = useState('');
-    const handleLocaleFilterChange = (name, value) => {
+    const handleLocaleFilterChange = (_, value) => {
         setLocaleFilter(value);
     };
     const localeFilterValues = ['all'].concat(
@@ -57,7 +62,7 @@ export default function UserTable() {
     const [workflowStateFilter, setWorkflowStateFilter] = useState(
         project.is_ohd ? 'afirmed' : 'project_access_requested'
     );
-    const handleWorkflowStateFilterChange = (name, value) => {
+    const handleWorkflowStateFilterChange = (_, value) => {
         setWorkflowStateFilter(value);
     };
     const workflowStateFilterValues = project.is_ohd
@@ -81,6 +86,7 @@ export default function UserTable() {
         projectFilter,
         roleFilter,
         mfaFilter,
+        projectManagerFilter,
         sorting
     );
 
@@ -265,14 +271,31 @@ export default function UserTable() {
                     keepOrder={true}
                 />
                 {project.is_ohd && (
-                    <SelectField
-                        className="u-mb-small"
-                        values={projects}
-                        label={t('activerecord.models.project.one')}
-                        attribute="project"
-                        handleChange={handleProjectFilterChange}
-                        withEmpty={true}
-                    />
+                    <>
+                        <SelectField
+                            className="u-mb-small"
+                            values={[
+                                { id: 'yes', name: t('boolean_value.true') },
+                                { id: 'no', name: t('boolean_value.false') },
+                            ]}
+                            label={t(
+                                'modules.project_access.archive_management_in'
+                            )}
+                            attribute="project_manager"
+                            handleChange={handleProjectManagerFilterChange}
+                            withEmpty={true}
+                            keepOrder={true}
+                        />
+
+                        <SelectField
+                            className="u-mb-small"
+                            values={projects}
+                            label={t('activerecord.models.project.one')}
+                            attribute="project"
+                            handleChange={handleProjectFilterChange}
+                            withEmpty={true}
+                        />
+                    </>
                 )}
                 {!project.is_ohd && (
                     <Fetch

--- a/app/javascript/modules/users/UserTable.js
+++ b/app/javascript/modules/users/UserTable.js
@@ -13,6 +13,7 @@ import { DateCell, TableWithPagination } from 'modules/tables';
 import { useSelector } from 'react-redux';
 
 import ArchiveManagementInCell from './ArchiveManagementInCell';
+import MfaStatusCell from './MfaStatusCell';
 import ProjectAccessGrantedCell from './ProjectAccessGrantedCell';
 import RolesCell from './RolesCell';
 import UserRowActions from './UserRowActions';
@@ -36,6 +37,11 @@ export default function UserTable() {
     const [roleFilter, setRoleFilter] = useState('');
     const handleRoleFilterChange = (name, value) => {
         setRoleFilter(value);
+    };
+
+    const [mfaFilter, setMfaFilter] = useState('');
+    const handleMfaFilterChange = (name, value) => {
+        setMfaFilter(value);
     };
 
     const [localeFilter, setLocaleFilter] = useState('');
@@ -74,6 +80,7 @@ export default function UserTable() {
         localeFilter,
         projectFilter,
         roleFilter,
+        mfaFilter,
         sorting
     );
 
@@ -101,6 +108,12 @@ export default function UserTable() {
                 id: 'email',
                 accessorFn: (row) => row.email,
                 header: t('activerecord.attributes.user.email'),
+            },
+            {
+                id: 'mfa',
+                enableSorting: false,
+                header: 'MFA',
+                cell: MfaStatusCell,
             },
         ],
         [locale]
@@ -239,6 +252,18 @@ export default function UserTable() {
                         withEmpty={false}
                     />
                 )}
+                <SelectField
+                    className="u-mb-small"
+                    values={[
+                        { id: 'enabled', name: t('enabled') },
+                        { id: 'disabled', name: t('disabled') },
+                    ]}
+                    label="MFA"
+                    attribute="mfa"
+                    handleChange={handleMfaFilterChange}
+                    withEmpty={true}
+                    keepOrder={true}
+                />
                 {project.is_ohd && (
                     <SelectField
                         className="u-mb-small"

--- a/app/javascript/modules/users/UserTable.js
+++ b/app/javascript/modules/users/UserTable.js
@@ -170,8 +170,8 @@ export default function UserTable() {
         [locale, project, dataPath]
     );
 
-    const actionColumns = useMemo(
-        () => [
+    const actionColumns = useMemo(() => {
+        const columns = [
             {
                 id: 'actions',
                 enableSorting: false,
@@ -179,16 +179,20 @@ export default function UserTable() {
                 accessorFn: getDataPath,
                 cell: UserRowActions,
             },
-            {
+        ];
+
+        if (!project.is_ohd) {
+            columns.push({
                 id: 'interviewPermissions',
                 enableSorting: false,
                 header: t('modules.tables.interviewPermissions'),
                 accessorFn: getDataPath,
                 cell: UserRowInterviewPermissions,
-            },
-        ],
-        [locale, project, dataPath]
-    );
+            });
+        }
+
+        return columns;
+    }, [locale, project, dataPath]);
 
     const columns = baseColumns
         .concat(!project.is_ohd ? projectColumns : ohdColumns)

--- a/app/javascript/modules/users/UserTable.js
+++ b/app/javascript/modules/users/UserTable.js
@@ -3,9 +3,9 @@ import { useMemo, useState } from 'react';
 import {
     Fetch,
     getCurrentProject,
-    getProjects,
     getRolesForCurrentProject,
     getRolesForCurrentProjectFetched,
+    useGetProjects,
 } from 'modules/data';
 import { SelectField } from 'modules/forms';
 import { useI18n } from 'modules/i18n';
@@ -22,7 +22,7 @@ import useUsers from './useUsers';
 export default function UserTable() {
     const { t, locale } = useI18n();
     const project = useSelector(getCurrentProject);
-    const projects = useSelector(getProjects);
+    const { projects } = useGetProjects({ all: true });
     const projectRoles = useSelector(getRolesForCurrentProject);
 
     const [page, setPage] = useState(1);

--- a/app/javascript/modules/users/UserTable.js
+++ b/app/javascript/modules/users/UserTable.js
@@ -3,6 +3,7 @@ import { useMemo, useState } from 'react';
 import {
     Fetch,
     getCurrentProject,
+    getCurrentUser,
     getRolesForCurrentProject,
     getRolesForCurrentProjectFetched,
     useGetProjects,
@@ -23,6 +24,7 @@ import useUsers from './useUsers';
 export default function UserTable() {
     const { t, locale } = useI18n();
     const project = useSelector(getCurrentProject);
+    const currentUser = useSelector(getCurrentUser);
     const { projects } = useGetProjects({ all: true });
     const projectRoles = useSelector(getRolesForCurrentProject);
 
@@ -47,6 +49,11 @@ export default function UserTable() {
     const [projectManagerFilter, setProjectManagerFilter] = useState('');
     const handleProjectManagerFilterChange = (_, value) => {
         setProjectManagerFilter(value);
+    };
+
+    const [superuserFilter, setSuperuserFilter] = useState('');
+    const handleSuperuserFilterChange = (_, value) => {
+        setSuperuserFilter(value);
     };
 
     const [localeFilter, setLocaleFilter] = useState('');
@@ -87,6 +94,7 @@ export default function UserTable() {
         roleFilter,
         mfaFilter,
         projectManagerFilter,
+        superuserFilter,
         sorting
     );
 
@@ -326,6 +334,20 @@ export default function UserTable() {
                                 withEmpty={true}
                             />
                         </Fetch>
+                    )}
+                    {currentUser?.admin && (
+                        <SelectField
+                            className="UserTable-filter"
+                            values={[
+                                { id: 'yes', name: t('boolean_value.true') },
+                                { id: 'no', name: t('boolean_value.false') },
+                            ]}
+                            label={t('user.superuser')}
+                            attribute="superuser"
+                            handleChange={handleSuperuserFilterChange}
+                            withEmpty={true}
+                            keepOrder={true}
+                        />
                     )}
                 </div>
             </TableWithPagination>

--- a/app/javascript/modules/users/useUsers.js
+++ b/app/javascript/modules/users/useUsers.js
@@ -10,6 +10,7 @@ export default function useUsers(
     roleFilter,
     mfaFilter,
     projectManagerFilter,
+    superuserFilter,
     sorting
 ) {
     const pathBase = usePathBase();
@@ -35,6 +36,9 @@ export default function useUsers(
     }
     if (projectManagerFilter) {
         dataPath += `&project_manager=${projectManagerFilter}`;
+    }
+    if (superuserFilter) {
+        dataPath += `&superuser=${superuserFilter}`;
     }
     if (sorting?.[0]) {
         dataPath += `&order=${sorting[0].id}&direction=${sorting[0].desc ? 'desc' : 'asc'}`;

--- a/app/javascript/modules/users/useUsers.js
+++ b/app/javascript/modules/users/useUsers.js
@@ -8,6 +8,7 @@ export default function useUsers(
     localeFilter,
     projectFilter,
     roleFilter,
+    mfaFilter,
     sorting
 ) {
     const pathBase = usePathBase();
@@ -27,6 +28,9 @@ export default function useUsers(
     }
     if (roleFilter) {
         dataPath += `&role=${roleFilter}`;
+    }
+    if (mfaFilter) {
+        dataPath += `&mfa=${mfaFilter}`;
     }
     if (sorting?.[0]) {
         dataPath += `&order=${sorting[0].id}&direction=${sorting[0].desc ? 'desc' : 'asc'}`;

--- a/app/javascript/modules/users/useUsers.js
+++ b/app/javascript/modules/users/useUsers.js
@@ -9,6 +9,7 @@ export default function useUsers(
     projectFilter,
     roleFilter,
     mfaFilter,
+    projectManagerFilter,
     sorting
 ) {
     const pathBase = usePathBase();
@@ -31,6 +32,9 @@ export default function useUsers(
     }
     if (mfaFilter) {
         dataPath += `&mfa=${mfaFilter}`;
+    }
+    if (projectManagerFilter) {
+        dataPath += `&project_manager=${projectManagerFilter}`;
     }
     if (sorting?.[0]) {
         dataPath += `&order=${sorting[0].id}&direction=${sorting[0].desc ? 'desc' : 'asc'}`;

--- a/app/javascript/modules/users/useUsers.js
+++ b/app/javascript/modules/users/useUsers.js
@@ -22,7 +22,7 @@ export default function useUsers(
     if (workflowStateFilter) {
         dataPath += `&workflow_state=${workflowStateFilter}`;
     }
-    if (localeFilter) {
+    if (localeFilter && localeFilter !== 'all') {
         dataPath += `&default_locale=${localeFilter}`;
     }
     if (projectFilter) {

--- a/app/javascript/modules/utils/formatDate.js
+++ b/app/javascript/modules/utils/formatDate.js
@@ -1,0 +1,17 @@
+export default function formatDate(
+    value,
+    locale,
+    options = { dateStyle: 'medium' }
+) {
+    if (!value) {
+        return null;
+    }
+
+    const date = value instanceof Date ? value : new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+        return null;
+    }
+
+    return date.toLocaleDateString(locale, options);
+}

--- a/app/javascript/modules/utils/formatDate.test.js
+++ b/app/javascript/modules/utils/formatDate.test.js
@@ -1,0 +1,29 @@
+import formatDate from './formatDate';
+
+describe('formatDate', () => {
+    it('formats dates with medium style by default', () => {
+        expect(formatDate('2026-06-01', 'en')).toBe('Jun 1, 2026');
+        expect(formatDate('2026-06-01', 'de')).toBe('01.06.2026');
+    });
+
+    it('formats dates with short style when specified', () => {
+        expect(formatDate('2026-06-01', 'en', { dateStyle: 'short' })).toBe(
+            '6/1/26'
+        );
+        expect(formatDate('2026-06-01', 'de', { dateStyle: 'short' })).toBe(
+            '01.06.26'
+        );
+    });
+
+    it('returns null for blank or invalid values', () => {
+        expect(formatDate(null, 'en')).toBeNull();
+        expect(formatDate('not-a-date', 'en')).toBeNull();
+    });
+
+    it('accepts Intl date format options', () => {
+        expect(formatDate('2026-06-01', 'en', { year: 'numeric' })).toBe(
+            '2026'
+        );
+        expect(formatDate('2026-06-01', 'de', { month: 'long' })).toBe('Juni');
+    });
+});

--- a/app/javascript/modules/utils/index.js
+++ b/app/javascript/modules/utils/index.js
@@ -2,6 +2,7 @@ export {
     formatCollectionCitation,
     formatProjectCitation,
 } from './formatCitation';
+export { default as formatDate } from './formatDate';
 export { default as formatDuration } from './formatDuration';
 export { default as formatNumber } from './formatNumber';
 export {

--- a/app/javascript/stylesheets/modules/_user.scss
+++ b/app/javascript/stylesheets/modules/_user.scss
@@ -31,3 +31,132 @@ div.account-page {
     }
   }
 }
+
+.UserTable {
+  > .u-mb-small {
+    .Input {
+      border: 1px solid $gray-light;
+      border-radius: 4px;
+      min-height: 38px;
+      padding: 0.25rem 0.75rem;
+    }
+  }
+
+  .UserTable-filters {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-bottom: $base-unit;
+  }
+
+  .UserTable-filter {
+    margin: 0;
+    max-width: 100%;
+
+    .Input {
+      appearance: none;
+      background-color: #fff;
+      border: 1px solid $gray-light;
+      border-radius: 4px;
+      color: $gray-darkest;
+      min-height: 38px;
+      padding: 0.25rem 2rem 0.25rem 0.75rem;
+      width: 100%;
+    }
+
+    select.Input {
+      background-image:
+        linear-gradient(45deg, transparent 50%, $gray-medium 50%),
+        linear-gradient(135deg, $gray-medium 50%, transparent 50%);
+      background-position:
+        calc(100% - 16px) 50%,
+        calc(100% - 11px) 50%;
+      background-repeat: no-repeat;
+      background-size: 5px 5px;
+    }
+
+    select.Input:focus {
+      border-color: var(--secondary-color);
+      box-shadow: 0 0 0 1px var(--secondary-color);
+    }
+  }
+
+  @include screen-m {
+    .UserTable-filters {
+      flex-direction: row;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    .UserTable-filter {
+      flex: 1;
+      max-width: 28rem;
+    }
+  }
+}
+
+.UserEdit {
+  color: $gray-darkest;
+}
+
+.UserEdit-section {
+  border-top: 1px solid $gray-lighter;
+  padding-top: $base-unit * 0.75;
+  margin-top: $base-unit;
+
+  &:first-child {
+    border-top: 0;
+    margin-top: 0;
+    padding-top: 0;
+  }
+
+  h3 {
+    font-size: $font-size-heading-h3;
+    line-height: $line-height-heading-h3;
+    margin: 0 0 ($base-unit * 0.35);
+  }
+
+  h4 {
+    color: $gray-darkest;
+    font-size: $font-size-large;
+    line-height: $line-height-large;
+    margin: ($base-unit * 0.5) 0 ($base-unit * 0.25);
+  }
+
+  .DetailList {
+    color: $gray-darkest;
+  }
+
+  .DetailList-item {
+    padding: 0.125rem 0;
+  }
+}
+
+.UserEdit-details {
+  display: grid;
+  gap: 0.125rem 1rem;
+}
+
+.UserEdit-detail {
+  font-size: $font-size-medium;
+  line-height: $line-height-medium;
+  margin: 0;
+}
+
+.UserEdit-detailName {
+  font-weight: bold;
+}
+
+#interview_permission {
+  margin-top: $base-unit;
+  .form-group,
+  .form-row {
+    margin: 0;
+  }
+}
+
+@media only screen and (min-width: 990px) {
+  #interview_permission.default .form-label {
+    width: 50%;
+  }
+}

--- a/app/serializers/user_project_serializer.rb
+++ b/app/serializers/user_project_serializer.rb
@@ -38,10 +38,10 @@ class UserProjectSerializer < ApplicationSerializer
   end
 
   def shortname
-    object.project.shortname
+    object.project&.shortname
   end
 
   def name
-    object.project.name
+    object.project&.name
   end
 end

--- a/app/serializers/user_project_serializer.rb
+++ b/app/serializers/user_project_serializer.rb
@@ -1,6 +1,8 @@
 class UserProjectSerializer < ApplicationSerializer
   attributes :id,
     :project_id,
+    :shortname,
+    :name,
     :user_id,
     :workflow_state,
     :workflow_states,
@@ -33,5 +35,13 @@ class UserProjectSerializer < ApplicationSerializer
 
   def default_locale
     object.user.default_locale
+  end
+
+  def shortname
+    object.project.shortname
+  end
+
+  def name
+    object.project.name
   end
 end

--- a/app/serializers/user_role_serializer.rb
+++ b/app/serializers/user_role_serializer.rb
@@ -1,8 +1,11 @@
 class UserRoleSerializer < ApplicationSerializer
   attributes :id,
     :name,
+    :archive_management,
     :desc,
     :project_id,
+    :project_shortname,
+    :project_name,
     :role_permissions#,
     #:permissions,
     #:created_at
@@ -15,12 +18,26 @@ class UserRoleSerializer < ApplicationSerializer
     object.role.name
   end
 
+  def archive_management
+    object.role.translations.any? do |translation|
+      translation.name == 'Archivmanagement'
+    end
+  end
+
   def desc 
     object.role.desc
   end
 
   def project_id
     object.role.project_id
+  end
+
+  def project_shortname
+    object.role.project.shortname
+  end
+
+  def project_name
+    object.role.project.name
   end
 
   def role_permissions

--- a/db/migrate/20260624093700_add_user_table_translations.rb
+++ b/db/migrate/20260624093700_add_user_table_translations.rb
@@ -36,6 +36,15 @@ class AddUserTableTranslations < ActiveRecord::Migration[8.0]
       uk: 'Ключ доступу',
       ar: 'مفتاح مرور',
     },
+    'user.superuser': {
+      de: 'Superuser',
+      en: 'Superuser',
+      el: 'Υπερχρήστης',
+      es: 'Superusuario',
+      ru: 'Суперпользователь',
+      uk: 'Суперкористувач',
+      ar: 'مستخدم متميز',
+    },
   }.freeze
 
   def up

--- a/db/migrate/20260624093700_add_user_table_translations.rb
+++ b/db/migrate/20260624093700_add_user_table_translations.rb
@@ -1,0 +1,57 @@
+class AddUserTableTranslations < ActiveRecord::Migration[8.0]
+  TRANSLATIONS = {
+    'enabled': {
+      de: 'aktiviert',
+      en: 'enabled',
+      el: 'ενεργοποιημένο',
+      es: 'habilitado',
+      ru: 'включено',
+      uk: 'увімкнено',
+      ar: 'مفعّل',
+    },
+    'disabled': {
+      de: 'deaktiviert',
+      en: 'disabled',
+      el: 'απενεργοποιημένο',
+      es: 'deshabilitado',
+      ru: 'выключено',
+      uk: 'вимкнено',
+      ar: 'معطّل',
+    },
+    'user.mfa_otp': {
+      de: 'Einmalpasswort (OTP)',
+      en: 'One-Time Password (OTP)',
+      el: 'Κωδικός μίας χρήσης (OTP)',
+      es: 'Contraseña de un solo uso (OTP)',
+      ru: 'Одноразовый пароль (OTP)',
+      uk: 'Одноразовий пароль (OTP)',
+      ar: 'كلمة مرور لمرة واحدة (OTP)',
+    },
+    'user.mfa_passkey': {
+      de: 'Passkey',
+      en: 'Passkey',
+      el: 'Κλειδί πρόσβασης',
+      es: 'Clave de acceso',
+      ru: 'Ключ доступа',
+      uk: 'Ключ доступу',
+      ar: 'مفتاح مرور',
+    },
+  }.freeze
+
+  def up
+    TRANSLATIONS.each do |key, translations|
+      tv = TranslationValue.find_or_create_by(key: key)
+
+      translations.each do |locale, value|
+        translation = tv.translations.find_or_initialize_by(locale: locale.to_s)
+        translation.update(value: value)
+      end
+    end
+  end
+
+  def down
+    TRANSLATIONS.keys.each do |key|
+      TranslationValue.where(key: key).destroy_all
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_09_085100) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_24_093700) do
   create_table "access_configs", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "project_id", null: false
     t.text "organization"

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,74 @@
+require 'test_helper'
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    host! 'test.portal.oral-history.localhost:47001'
+    @access_token = Doorkeeper::AccessToken.create!(
+      resource_owner_id: User.find_by!(email: 'alice@example.com').id
+    ).token
+  end
+
+  test 'ignores invalid default locale filter values' do
+    users_json(page: 1, workflow_state: 'afirmed')
+    assert_response :success
+    unfiltered_total = JSON.parse(response.body).fetch('total')
+
+    users_json(
+      page: 1,
+      workflow_state: 'afirmed',
+      default_locale: 'all'
+    )
+    assert_response :success
+    assert_equal unfiltered_total, JSON.parse(response.body).fetch('total')
+
+    users_json(
+      page: 1,
+      workflow_state: 'afirmed',
+      default_locale: 'not-a-locale'
+    )
+    assert_response :success
+    assert_equal unfiltered_total, JSON.parse(response.body).fetch('total')
+  end
+
+  test 'allows global user locales not available on umbrella project' do
+    assert_not_includes Project.find_by!(shortname: 'ohd').available_locales, 'ru'
+
+    user = User.new(
+      login: 'russian-user@example.com',
+      email: 'russian-user@example.com',
+      password: 'Password123!',
+      password_confirmation: 'Password123!',
+      first_name: 'Russian',
+      last_name: 'User',
+      tos_agreement: true,
+      tos_agreed_at: DateTime.now,
+      priv_agreement: true,
+      country: 'Germany',
+      street: 'Test Street 1',
+      city: 'Berlin',
+      default_locale: 'ru'
+    )
+    user.skip_confirmation_notification!
+    user.save!
+    user.confirm
+    user.afirm!
+
+    users_json(
+      page: 1,
+      workflow_state: 'afirmed',
+      default_locale: 'ru'
+    )
+    assert_response :success
+
+    user_ids = JSON.parse(response.body).
+      fetch('data').
+      map { |payload| payload.fetch('id') }
+    assert_includes user_ids, user.id
+  end
+
+  private
+
+  def users_json(params)
+    get '/ohd/en/users.json', params: params.merge(access_token: @access_token)
+  end
+end

--- a/test/serializers/user_project_serializer_test.rb
+++ b/test/serializers/user_project_serializer_test.rb
@@ -10,4 +10,12 @@ class UserProjectSerializerTest < ActiveSupport::TestCase
     assert_equal 'test', serializer.shortname
     assert_equal 'Test Project', serializer.name
   end
+
+  test 'handles missing project' do
+    user_project = OpenStruct.new(project: nil)
+    serializer = UserProjectSerializer.new(user_project)
+
+    assert_nil serializer.shortname
+    assert_nil serializer.name
+  end
 end

--- a/test/serializers/user_project_serializer_test.rb
+++ b/test/serializers/user_project_serializer_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+require 'ostruct'
+
+class UserProjectSerializerTest < ActiveSupport::TestCase
+  test 'includes project shortname and name' do
+    project = OpenStruct.new(shortname: 'test', name: 'Test Project')
+    user_project = OpenStruct.new(project: project)
+    serializer = UserProjectSerializer.new(user_project)
+
+    assert_equal 'test', serializer.shortname
+    assert_equal 'Test Project', serializer.name
+  end
+end

--- a/test/serializers/user_role_serializer_test.rb
+++ b/test/serializers/user_role_serializer_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+require 'ostruct'
+
+class UserRoleSerializerTest < ActiveSupport::TestCase
+  test 'includes archive management flag and project details' do
+    project = OpenStruct.new(shortname: 'test', name: 'Test Project')
+    role = OpenStruct.new(
+      project_id: 1,
+      project: project,
+      translations: [
+        OpenStruct.new(locale: 'en', name: 'Archive Manager'),
+        OpenStruct.new(locale: 'de', name: 'Archivmanagement')
+      ]
+    )
+    serializer = UserRoleSerializer.new(OpenStruct.new(role: role))
+
+    assert serializer.archive_management
+    assert_equal 'test', serializer.project_shortname
+    assert_equal 'Test Project', serializer.project_name
+  end
+end


### PR DESCRIPTION
When Redux didn't have data for all projects, column for archive management in UserTable displayed unknown values.

This fix adds project shortname and name to users endpoint and displays them correctly in the table instead of relying on Redux project data.

- Adds a column and a filter for Multi Factor Authentication (MFA).
- Adds a filter for archive manager
- Improves UI display of filters
- Fixes display of project access in modal when clicking the pencil icon