### PR TITLE
fix(auth): split logged-in and project-access AuthShow gates

### DIFF
--- a/app/javascript/modules/admin/EditInterview.js
+++ b/app/javascript/modules/admin/EditInterview.js
@@ -17,7 +17,7 @@ export default function EditInterview() {
                 <Helmet>
                     <title>{t('edit.interview.new')}</title>
                 </Helmet>
-                <AuthShowContainer ifLoggedIn>
+                <AuthShowContainer hasProjectAccess>
                     <h1 className="Page-main-title">
                         {t('edit.interview.new')}
                     </h1>

--- a/app/javascript/modules/admin/EditProjectAccessConfig.js
+++ b/app/javascript/modules/admin/EditProjectAccessConfig.js
@@ -115,7 +115,7 @@ export default function EditProjectAccessConfig() {
                 <Helmet>
                     <title>{t(`edit.project.access_config`)}</title>
                 </Helmet>
-                <AuthShowContainer ifLoggedIn={true}>
+                <AuthShowContainer hasProjectAccess>
                     <h1 className="Page-main-title">
                         {t(`edit.project.access_config`)}
                     </h1>

--- a/app/javascript/modules/admin/EditProjectConfig.js
+++ b/app/javascript/modules/admin/EditProjectConfig.js
@@ -141,7 +141,7 @@ export default function EditProjectConfig() {
                 <Helmet>
                     <title>{t(`edit.project.config`)}</title>
                 </Helmet>
-                <AuthShowContainer ifLoggedIn={true}>
+                <AuthShowContainer hasProjectAccess>
                     <h1 className="Page-main-title">
                         {t(`edit.project.config`)}
                     </h1>

--- a/app/javascript/modules/admin/EditProjectDisplay.js
+++ b/app/javascript/modules/admin/EditProjectDisplay.js
@@ -54,7 +54,7 @@ export default function EditProjectDisplay() {
                 <Helmet>
                     <title>{t(`edit.project.display`)}</title>
                 </Helmet>
-                <AuthShowContainer ifLoggedIn={true}>
+                <AuthShowContainer hasProjectAccess>
                     <h1 className="Page-main-title">
                         {t(`edit.project.display`)}
                     </h1>

--- a/app/javascript/modules/admin/EditProjectInfo.js
+++ b/app/javascript/modules/admin/EditProjectInfo.js
@@ -71,7 +71,7 @@ export default function EditProjectInfo() {
                 <Helmet>
                     <title>{t('edit.project.info')}</title>
                 </Helmet>
-                <AuthShowContainer ifLoggedIn={true}>
+                <AuthShowContainer hasProjectAccess>
                     <h1 className="Page-main-title">
                         {t(`edit.project.info`)}
                     </h1>

--- a/app/javascript/modules/admin/EventTypesAdminPage.js
+++ b/app/javascript/modules/admin/EventTypesAdminPage.js
@@ -80,7 +80,7 @@ export default function EventTypesAdminPage() {
                     <title>{t(`activerecord.models.${scope}.other`)}</title>
                 </Helmet>
 
-                <AuthShowContainer ifLoggedIn>
+                <AuthShowContainer hasProjectAccess>
                     <h1 className="Page-main-title">
                         {t(`activerecord.models.${scope}.other`)}
                     </h1>

--- a/app/javascript/modules/admin/HelpTextAdminPage.js
+++ b/app/javascript/modules/admin/HelpTextAdminPage.js
@@ -24,7 +24,7 @@ export default function HelpTextAdminPage() {
                     <title>{t('activerecord.models.help_text.other')}</title>
                 </Helmet>
 
-                <AuthShowContainer ifLoggedIn>
+                <AuthShowContainer hasProjectAccess>
                     <h1 className="Page-main-title">
                         {t('activerecord.models.help_text.other')}
                     </h1>

--- a/app/javascript/modules/admin/InstanceSettingAdminPage.js
+++ b/app/javascript/modules/admin/InstanceSettingAdminPage.js
@@ -305,7 +305,7 @@ export default function InstanceSettingAdminPage() {
                     <title>{t('edit.instance.title')}</title>
                 </Helmet>
 
-                <AuthShowContainer ifLoggedIn>
+                <AuthShowContainer hasProjectAccess>
                     <AuthorizedContent
                         object={{ type: 'InstanceSetting' }}
                         action="update"

--- a/app/javascript/modules/admin/PeopleAdminPage.js
+++ b/app/javascript/modules/admin/PeopleAdminPage.js
@@ -45,7 +45,7 @@ export default function PeopleAdminPage() {
                     <title>{t('activerecord.models.person.other')}</title>
                 </Helmet>
 
-                <AuthShowContainer ifLoggedIn>
+                <AuthShowContainer hasProjectAccess>
                     <h1 className="Page-main-title">
                         {peopleCount} {t('activerecord.models.person.other')}
                     </h1>

--- a/app/javascript/modules/admin/StatisticsAdminPage.jsx
+++ b/app/javascript/modules/admin/StatisticsAdminPage.jsx
@@ -47,7 +47,7 @@ export default function StatisticsAdminPage() {
                 <title>{t('edit.statistics.title')}</title>
             </Helmet>
 
-            <AuthShowContainer ifLoggedIn>
+            <AuthShowContainer hasProjectAccess>
                 <AuthorizedContent object={{ type: 'User' }} action="update">
                     <h1 className="Page-main-title">
                         {t('edit.statistics.title')}

--- a/app/javascript/modules/admin/UploadsPage.js
+++ b/app/javascript/modules/admin/UploadsPage.js
@@ -14,7 +14,7 @@ export default function UploadsPage() {
                 <Helmet>
                     <title>{t(`edit.upload.upload`)}</title>
                 </Helmet>
-                <AuthShowContainer ifLoggedIn>
+                <AuthShowContainer hasProjectAccess>
                     <h1 className="Page-main-title">
                         {t(`edit.upload.upload`)}
                     </h1>

--- a/app/javascript/modules/admin/UsersAdminPage.js
+++ b/app/javascript/modules/admin/UsersAdminPage.js
@@ -12,7 +12,7 @@ export default function UsersAdminPage() {
                 <title>{t('activerecord.models.user.other')}</title>
             </Helmet>
 
-            <AuthShowContainer ifLoggedIn>
+            <AuthShowContainer hasProjectAccess>
                 <AuthorizedContent object={{ type: 'User' }} action="update">
                     <UserTable />
                 </AuthorizedContent>

--- a/app/javascript/modules/admin/WrappedDataList.js
+++ b/app/javascript/modules/admin/WrappedDataList.js
@@ -156,7 +156,7 @@ export default function WrappedDataList({
                     <title>{t(`activerecord.models.${scope}.other`)}</title>
                 </Helmet>
 
-                <AuthShowContainer ifLoggedIn={true}>
+                <AuthShowContainer hasProjectAccess>
                     <h1 className="Page-main-title">
                         {t(`activerecord.models.${scope}.other`)}
                     </h1>

--- a/app/javascript/modules/auth/AuthShow.js
+++ b/app/javascript/modules/auth/AuthShow.js
@@ -9,10 +9,11 @@ import { useAuthorization } from './authorization-hook';
  *
  * @param {Object} props
  * @param {boolean} props.isLoggedIn Real auth state from account/session store.
- * @param {boolean} props.ifLoggedIn Enables the "logged-in access" branch.
- * This branch still requires project-level access conditions (admin, project
- * grant flags, or granted user_project access) and restricted interview
- * permission when applicable.
+ * @param {boolean} props.ifLoggedIn Enables rendering for logged-in users.
+ * @param {boolean} props.hasProjectAccess Enables the project-access branch.
+ * This branch requires project-level access conditions (admin, project grant
+ * flags, or granted user_project access) and restricted interview permission
+ * when applicable.
  * @param {boolean} props.ifLoggedOut Enables the "logged-out" branch. In
  * current logic this also allows rendering for logged-in users on restricted
  * interviews when they do not have permission.
@@ -30,6 +31,7 @@ import { useAuthorization } from './authorization-hook';
 export default function AuthShow({
     isLoggedIn,
     ifLoggedIn,
+    hasProjectAccess,
     ifLoggedOut,
     ifNoProject,
     ifCatalog,
@@ -54,25 +56,27 @@ export default function AuthShow({
             userProject?.workflow_state === 'project_access_granted'
     );
 
-    if (
-        // logged in and registered for the current project
+    if (isLoggedIn && ifLoggedIn && user) {
+        return children;
+    } else if (
+        // Logged in and with access permissions for the current project
         (((isInterviewRestricted && canViewInterview) ||
             !isInterviewRestricted) &&
             isLoggedIn &&
-            ifLoggedIn &&
+            hasProjectAccess &&
             user &&
             (user.admin ||
                 project?.grant_access_without_login ||
                 project?.grant_project_access_instantly ||
                 hasGrantedProjectAccess)) ||
-        // catalog-project
+        // Catalog project
         (ifCatalog && isCatalogProject)
     ) {
         return children;
     } else if (
-        // logged out
+        // Logged out
         (!isLoggedIn && ifLoggedOut) ||
-        // logged in and NOT registered for the current project
+        // Logged in and NO access permissions for the current project
         (isLoggedIn &&
             ifNoProject &&
             user &&
@@ -85,7 +89,7 @@ export default function AuthShow({
             isInterviewRestricted &&
             !canViewInterview)
     ) {
-        // logged out or still not registered for a project
+        // Logged out or still not registered for a project
         return children;
     } else {
         return null;
@@ -95,6 +99,7 @@ export default function AuthShow({
 AuthShow.propTypes = {
     isLoggedIn: PropTypes.bool,
     ifLoggedIn: PropTypes.bool,
+    hasProjectAccess: PropTypes.bool,
     ifLoggedOut: PropTypes.bool,
     ifNoProject: PropTypes.bool,
     ifCatalog: PropTypes.bool,

--- a/app/javascript/modules/auth/AuthShow.test.js
+++ b/app/javascript/modules/auth/AuthShow.test.js
@@ -16,6 +16,7 @@ function renderAuthShow(overrides = {}) {
     const props = {
         isLoggedIn: false,
         ifLoggedIn: false,
+        hasProjectAccess: false,
         ifLoggedOut: false,
         ifNoProject: false,
         ifCatalog: false,
@@ -61,7 +62,17 @@ describe('AuthShow', () => {
         jest.clearAllMocks();
     });
 
-    it('renders children for logged in users with explicit project_access_granted', () => {
+    it('renders children for logged in users when ifLoggedIn is set', () => {
+        const html = renderAuthShow({
+            isLoggedIn: true,
+            ifLoggedIn: true,
+            user: buildUser({ user_projects: {} }),
+        });
+
+        expect(html).toContain('VISIBLE');
+    });
+
+    it('renders children for project-access users with explicit project_access_granted', () => {
         useProject.mockReturnValue({
             project: buildProject({ id: 42 }),
         });
@@ -74,7 +85,7 @@ describe('AuthShow', () => {
 
         const html = renderAuthShow({
             isLoggedIn: true,
-            ifLoggedIn: true,
+            hasProjectAccess: true,
             user,
         });
 
@@ -127,7 +138,7 @@ describe('AuthShow', () => {
 
         const html = renderAuthShow({
             isLoggedIn: true,
-            ifLoggedIn: true,
+            hasProjectAccess: true,
             user: buildUser(),
         });
 
@@ -157,10 +168,10 @@ describe('AuthShow', () => {
         expect(html).toBe('');
     });
 
-    it('returns null for logged in users without access when only ifLoggedIn is set', () => {
+    it('returns null for logged in users without access when only hasProjectAccess is set', () => {
         const html = renderAuthShow({
             isLoggedIn: true,
-            ifLoggedIn: true,
+            hasProjectAccess: true,
             user: buildUser({ user_projects: {} }),
         });
 
@@ -179,10 +190,10 @@ describe('AuthShow', () => {
         expect(html).toBe('');
     });
 
-    it('returns null for restricted interviews in ifLoggedIn mode when user lacks permission', () => {
+    it('returns null for restricted interviews in project-access mode when user lacks permission', () => {
         const html = renderAuthShow({
             isLoggedIn: true,
-            ifLoggedIn: true,
+            hasProjectAccess: true,
             user: buildUser({ interview_permissions: [] }),
             interview: { id: 7, workflow_state: 'restricted' },
         });

--- a/app/javascript/modules/interview-metadata/InterviewTextMaterials.js
+++ b/app/javascript/modules/interview-metadata/InterviewTextMaterials.js
@@ -73,7 +73,7 @@ export default function InterviewTextMaterials({
             {!isCatalog &&
                 showTranscriptPDF &&
                 interview.alpha3s_with_transcript?.length > 0 && (
-                    <AuthShowContainer ifLoggedIn>
+                    <AuthShowContainer hasProjectAccess>
                         <p key="transcript-downloads" id="transcript-downloads">
                             <span className="flyout-content-label">
                                 {t('transcript')}:

--- a/app/javascript/modules/interview/components/Interview.js
+++ b/app/javascript/modules/interview/components/Interview.js
@@ -65,7 +65,7 @@ export default function Interview({
                 <Helmet>
                     <title>{documentTitle}</title>
                 </Helmet>
-                <AuthShowContainer ifLoggedIn>
+                <AuthShowContainer hasProjectAccess>
                     <AuthorizedContent
                         object={interview}
                         action="show"

--- a/app/javascript/modules/person/Biography.js
+++ b/app/javascript/modules/person/Biography.js
@@ -38,7 +38,7 @@ export default function Biography() {
     return (
         <div className={classNames('ContentField', 'LoadingOverlay')}>
             {firstPublicEntry && (
-                <AuthShowContainer ifLoggedIn={true}>
+                <AuthShowContainer hasProjectAccess>
                     <p>
                         <span className="flyout-content-label">
                             {t('history')}:

--- a/app/javascript/modules/person/NameOrPseudonym.js
+++ b/app/javascript/modules/person/NameOrPseudonym.js
@@ -33,7 +33,7 @@ export default function NameOrPseudonym({
         }
 
         return (
-            <AuthShowContainer ifLoggedIn>
+            <AuthShowContainer hasProjectAccess>
                 <ContentField label={label} value={value} fetching={fetching} />
             </AuthShowContainer>
         );
@@ -46,7 +46,7 @@ export default function NameOrPseudonym({
 
     return (
         <>
-            <AuthShowContainer ifLoggedIn>
+            <AuthShowContainer hasProjectAccess>
                 <ContentField label={label} value={value} fetching={fetching}>
                     <AuthorizedContent object={person} action="update">
                         <Modal

--- a/app/javascript/modules/search/components/ArchiveSearchForm.js
+++ b/app/javascript/modules/search/components/ArchiveSearchForm.js
@@ -97,7 +97,7 @@ export default function ArchiveSearchForm({ projectId, project, hideSidebar }) {
                         onChange={setFulltextInput}
                     />
                 ) : (
-                    <AuthShowContainer ifLoggedIn ifCatalog ifNoProject>
+                    <AuthShowContainer hasProjectAccess ifCatalog ifNoProject>
                         <ArchiveSearchFormInput
                             value={fulltextInput}
                             projectId={projectId}

--- a/app/javascript/modules/sidebar/components/InterviewTabPanel.js
+++ b/app/javascript/modules/sidebar/components/InterviewTabPanel.js
@@ -134,7 +134,7 @@ export default function InterviewTabPanel({
                                 </SubTab>
                             </AuthorizedContent>
                         </AuthShowContainer>
-                        <AuthShowContainer ifLoggedIn>
+                        <AuthShowContainer hasProjectAccess>
                             <AuthorizedContent
                                 object={interview}
                                 action="show"
@@ -210,8 +210,8 @@ export default function InterviewTabPanel({
                 </AuthorizedContent>
 
                 {projectId !== PROJECT_CAMPSCAPES && (
-                    <AuthShowContainer ifLoggedIn>
-                        <AuthShowContainer ifLoggedIn={hasMap}>
+                    <AuthShowContainer hasProjectAccess>
+                        <AuthShowContainer hasProjectAccess={hasMap}>
                             <AuthorizedContent
                                 object={interview}
                                 action="show"

--- a/app/javascript/modules/sidebar/components/WorkbookTabPanel.js
+++ b/app/javascript/modules/sidebar/components/WorkbookTabPanel.js
@@ -8,7 +8,7 @@ export default function WorkbookTabPanel() {
 
     return (
         <ErrorBoundary small>
-            <AuthShowContainer ifLoggedIn ifNoProject>
+            <AuthShowContainer hasProjectAccess ifNoProject>
                 <h3 className="SidebarTabs-title">{t('user_content')}</h3>
                 <div className="flyout-sub-tabs-container flyout-folder">
                     <Workbook />

--- a/app/javascript/modules/user/components/AccountPage.js
+++ b/app/javascript/modules/user/components/AccountPage.js
@@ -29,7 +29,7 @@ export default function AccountPage() {
                 <title>{t('account_page')}</title>
             </Helmet>
             <ErrorBoundary>
-                <AuthShowContainer ifLoggedIn ifNoProject>
+                <AuthShowContainer hasProjectAccess ifNoProject>
                     {isEditor && <HelpText code="account_page" />}
 
                     <div className="account-page-header">


### PR DESCRIPTION
Restore ifLoggedIn to mean any authenticated user, add hasProjectAccess for the previous stricter project access behavior, and keep save search visible to logged-in users.