### PR TITLE
Fix/locale routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# Guidelines for Claude
+
+## Git commits
+
+- Do **not** add `Co-authored-by:` trailers to commit messages.
+- Do not add "Generated with Claude Code" or similar attribution lines.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -310,7 +310,14 @@ Rails.application.routes.draw do
   # In production this should be the ohd-domain
   constraints(lambda { |request| OHD_DOMAIN == request.base_url }) do
     # Main-level routes (no :project_id), e.g. homepage
-    scope "/:locale" do
+    # The portal itself is only served in German and English, so the locale is
+    # constrained to de|en. Other locales are only valid below as
+    # /:project_id/:locale (e.g. /cd/ru). This also keeps short URLs from being
+    # misinterpreted as a locale: junk like /sitemap.xml or /testscript.php and
+    # two-letter project shortnames like /cd now fall through to the
+    # project-level routes below (/cd redirects to /cd/<default_locale>) or 404
+    # instead of hitting projects#index with a bogus locale.
+    scope "/:locale", :constraints => { locale: /(?:de|en)/ } do
       get "", to: "projects#index"
       get "/", to: "projects#index"
       resource :homepage_settings, only: [:show, :update]
@@ -336,6 +343,9 @@ Rails.application.routes.draw do
     scope "/:project_id", :constraints => { project_id: /[\-a-z0-9]{1,11}[a-z]/ } do
       get "/", to: redirect{|params, request|
         project = Project.by_identifier(params[:project_id])
+        # Unknown shortname (e.g. a bot hitting /sitemap.xml or /testscript.php
+        # that slips past the locale scope): return 404 instead of 500 on nil.
+        raise ActionController::RoutingError, "No project: #{params[:project_id]}" if project.nil?
         "/#{project.identifier}/#{project.default_locale}"
       }
       scope "/:locale", :constraints => { locale: /[a-z]{2}/ } do

--- a/test/integration/short_url_routing_test.rb
+++ b/test/integration/short_url_routing_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+# Regression tests for the short, single-segment URLs on the OHD portal domain.
+#
+# Valid short URLs are only:
+#   * /de and /en          -> portal homepage (projects#index)
+#   * /<project-shortname>  -> redirect to /<project-shortname>/<default_locale>
+#
+# Anything else (bots hitting /sitemap.xml, /testscript.php, …) must return 404,
+# not 500. See config/routes.rb (OHD_DOMAIN block).
+class ShortUrlRoutingTest < ActionDispatch::IntegrationTest
+  setup do
+    host! 'test.portal.oral-history.localhost:47001'
+  end
+
+  test 'portal homepage is served for the de and en locales' do
+    get '/de'
+    assert_response :success
+
+    get '/en'
+    assert_response :success
+  end
+
+  test 'a known project shortname redirects to its default locale' do
+    # The seeded test project has shortname "test" and default_locale "en".
+    get '/test'
+    assert_redirected_to '/test/en'
+  end
+
+  test 'unknown short urls return 404 instead of 500' do
+    # Note: real static files in public/ (e.g. robots.txt, favicon.ico) are
+    # served before routing and are intentionally not covered here.
+    ['/sitemap.xml', '/testscript.php', '/wp-login.php'].each do |path|
+      get path
+      assert_response :not_found,
+        "expected 404 for #{path}, got #{response.status}"
+    end
+  end
+end


### PR DESCRIPTION
Constrain the portal locale to de|en so junk URLs like /sitemap.xml and two-letter shortnames like /cd no longer fall into projects#index, and raise RoutingError (404) when a project shortname does not exist instead of calling identifier on nil. Adds a routing test.