### PR TITLE
fix: ensure latex escapes once at render boundary

### DIFF
--- a/app/helpers/latex_helper.rb
+++ b/app/helpers/latex_helper.rb
@@ -199,6 +199,8 @@ module LatexHelper
       rtl_speaker = ''
       ltr_speaker = ''
     else
+      speaker = latex_escape(speaker.to_s)
+
       rtl_speaker = rtl ? " :#{speaker}" : ''
       ltr_speaker = rtl ? '' : "#{speaker}: "
     end

--- a/app/helpers/latex_helper.rb
+++ b/app/helpers/latex_helper.rb
@@ -67,6 +67,25 @@ module LatexHelper
     "\\textenglish{#{latex_escape(text)}}"
   end
 
+  # Convert multiline text to LaTeX, escaping special characters and joining lines with LaTeX line breaks.
+  def latex_multiline_text(text, convert_quotes: false)
+    value = text.to_s
+    value = value.gsub(/\"/, '``') if convert_quotes
+
+    value
+      .split(/\r?\n/, -1)
+      .map { |line| latex_escape(line) }
+      .join('~\newline~')
+      .html_safe
+  end
+
+  # Sanitize multiline text for LaTeX by removing HTML tags and escaping special characters.
+  def latex_sanitized_multiline_text(text)
+    latex_multiline_text(
+      ActionView::Base.full_sanitizer.sanitize(text).gsub("&amp;", "&"),
+    )
+  end
+
   # Wrap text in script-aware LaTeX commands so RTL/Indic glyph shaping works.
   def latex_multiscript(text)
     return '' if text.nil?

--- a/app/models/biographical_entry.rb
+++ b/app/models/biographical_entry.rb
@@ -24,13 +24,6 @@ class BiographicalEntry < ApplicationRecord
     person.interviews.first && person.interviews.first.id
   end
 
-  def for_latex(locale)
-    sanitized_text = ActionView::Base.full_sanitizer.sanitize(text(locale))
-      .gsub("&amp;", "&")
-    escaped_text = LatexToPdf.escape_latex(sanitized_text)
-    escaped_text.gsub(/\r?\n/, '~\newline~')
-  end
-
   def public?
     workflow_state == 'public'
   end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -585,11 +585,6 @@ class Interview < ApplicationRecord
     !!t && !t.observations.blank?
   end
 
-  def observations_for_latex(locale)
-    escaped_text = LatexToPdf.escape_latex(observations(locale).gsub(/\"/, '``'))
-    escaped_text.gsub(/\r?\n/, '~\newline~')
-  end
-
   def observations_public?
     public_attributes = properties.fetch(:public_attributes, {})
     public_attributes.fetch('observations', false)

--- a/app/views/latex/_citation.pdf.erb
+++ b/app/views/latex/_citation.pdf.erb
@@ -1,17 +1,21 @@
 <%= render partial: "latex/title",
            locals: {
-               title: "#{latex_escape(TranslationValue.for('citation', @locale))}:",
+               title: "#{TranslationValue.for('citation', @locale)}:",
                space_above: 6,
                space_below: 0,
                font_size: 13
            } %>
 
-\par{
-  <%= "#{interviewee_name},
+<%
+  citation = "#{interviewee_name},
   #{TranslationValue.for('interview', @locale)}
   #{@interview.archive_id},
   #{@interview.created_at.strftime("%d.%m.%Y")},
   #{TranslationValue.for('interview_archive', @locale)} #{current_project.name(@locale)}, #{current_project.archive_domain},
   #{TranslationValue.for('doi.name', @locale)}: #{Rails.configuration.datacite['prefix'] + @interview.archive_id},
-  (#{TranslationValue.for('called', @locale)}: #{Date.today.strftime("%d.%m.%Y")})" %>
+  (#{TranslationValue.for('called', @locale)}: #{Date.today.strftime("%d.%m.%Y")})"
+%>
+
+\par{
+  <%= latex_multiscript(citation) %>
 }

--- a/app/views/latex/_legend.pdf.erb
+++ b/app/views/latex/_legend.pdf.erb
@@ -1,6 +1,6 @@
 <%= render partial: "latex/title",
            locals: {
-               title: latex_escape(TranslationValue.for('legend.title', header_locale)),
+               title: TranslationValue.for('legend.title', header_locale),
                space_above: 0,
                space_below: 0.01,
                font_size: 13
@@ -37,15 +37,15 @@
     \vspace*{0.2cm}
     \item[\normalfont{(???)}] <%= latex_escape(TranslationValue.for('legend.zwar.unclear', header_locale)) %>
     \vspace*{0.2cm}
-    \item[\normalfont{(<%= TranslationValue.for(:word, header_locale) %> ?)}] <%= latex_escape(TranslationValue.for('legend.zwar.unsure', header_locale)) %>
+    \item[\normalfont{(<%= latex_escape(TranslationValue.for(:word, header_locale)) %> ?)}] <%= latex_escape(TranslationValue.for('legend.zwar.unsure', header_locale)) %>
     \vspace*{0.2cm}
     \item[\normalfont{[x]}] <%= latex_escape(TranslationValue.for('legend.zwar.break', header_locale)) %>
     \vspace*{0.2cm}
-    \item[\textit{<%= TranslationValue.for(:italic, header_locale) %>}] <%= latex_escape(TranslationValue.for('legend.zwar.italic', header_locale)) %>
+    \item[\textit{<%= latex_escape(TranslationValue.for(:italic, header_locale)) %>}] <%= latex_escape(TranslationValue.for('legend.zwar.italic', header_locale)) %>
     \vspace*{0.2cm}
     \item[\normalfont{"xyz"}] <%= latex_escape(TranslationValue.for('legend.zwar.quote', header_locale)) %>
     \vspace*{0.2cm}
-    \item[\normalfont{{<%= TranslationValue.for(:text, header_locale) %>} <%= TranslationValue.for(:or, header_locale) %> {(<%= TranslationValue.for(:text, header_locale) %>)}}] <%= latex_escape(TranslationValue.for('legend.zwar.annotation', header_locale)) %>
+    \item[\normalfont{{<%= latex_escape(TranslationValue.for(:text, header_locale)) %>} <%= latex_escape(TranslationValue.for(:or, header_locale)) %> {(<%= latex_escape(TranslationValue.for(:text, header_locale)) %>)}}] <%= latex_escape(TranslationValue.for('legend.zwar.annotation', header_locale)) %>
     \vspace*{0.2cm}
     \item[\normalfont{<***>}] <%= latex_escape(TranslationValue.for('legend.zwar.tape_end', header_locale)) %>
     \vspace*{0.2cm}
@@ -66,21 +66,20 @@
     \vspace*{0.2cm}
     \item[\normalfont{<l(es) xyz>; <l(es-de)>; <l(de-es)>}] <%= latex_escape(TranslationValue.for('legend.default.lexical_phenomenon', header_locale)) %>
     \vspace*{0.2cm}
-    \item[\normalfont{<s(<%= TranslationValue.for('legend.default.vocal_shift', header_locale) %>) xyz>}] <%= latex_escape(TranslationValue.for('legend.default.changed_voice', header_locale)) %>
+    \item[\normalfont{<s(<%= latex_escape(TranslationValue.for('legend.default.vocal_shift', header_locale)) %>) xyz>}] <%= latex_escape(TranslationValue.for('legend.default.changed_voice', header_locale)) %>
     \vspace*{0.2cm}
     \item[\normalfont{<sim>}] <%= latex_escape(TranslationValue.for('legend.default.simultaneous', header_locale)) %>
     \vspace*{0.2cm}
-    \item[\normalfont{<nl(<%= TranslationValue.for('legend.default.sound', header_locale) %>) xyz>}] <%= latex_escape(TranslationValue.for('legend.default.non_linguistic', header_locale)) %>
+    \item[\normalfont{<nl(<%= latex_escape(TranslationValue.for('legend.default.sound', header_locale)) %>) xyz>}] <%= latex_escape(TranslationValue.for('legend.default.non_linguistic', header_locale)) %>
     \vspace*{0.2cm}
-    \item[\normalfont{<v(<%= TranslationValue.for('legend.default.fonetic_expression', header_locale) %>)>}] <%= latex_escape(TranslationValue.for('legend.default.non_verbal', header_locale)) %>
+    \item[\normalfont{<v(<%= latex_escape(TranslationValue.for('legend.default.fonetic_expression', header_locale)) %>)>}] <%= latex_escape(TranslationValue.for('legend.default.non_verbal', header_locale)) %>
     \vspace*{0.2cm}
-    \item[\normalfont{<g(<%= TranslationValue.for('legend.default.gesture_type', header_locale) %>) xyz>}] <%= latex_escape(TranslationValue.for('legend.default.gesture', header_locale)) %>
+    \item[\normalfont{<g(<%= latex_escape(TranslationValue.for('legend.default.gesture_type', header_locale)) %>) xyz>}] <%= latex_escape(TranslationValue.for('legend.default.gesture', header_locale)) %>
     \vspace*{0.2cm}
-    \item[\normalfont{<m(<%= TranslationValue.for('legend.default.expression_type', header_locale) %>) xyz>}] <%= latex_escape(TranslationValue.for('legend.default.facial_expression', header_locale)) %>
+    \item[\normalfont{<m(<%= latex_escape(TranslationValue.for('legend.default.expression_type', header_locale)) %>) xyz>}] <%= latex_escape(TranslationValue.for('legend.default.facial_expression', header_locale)) %>
     \vspace*{0.2cm}
     \item[\normalfont{<n>}] <%= latex_escape(TranslationValue.for('legend.default.notes', header_locale)) %>
     \vspace*{0.2cm}
   \end{description}
 }
 <% end %>
-

--- a/app/views/latex/_observation.pdf.erb
+++ b/app/views/latex/_observation.pdf.erb
@@ -1,6 +1,6 @@
 <%= render partial: "latex/title",
            locals: {
-               title: latex_escape(TranslationValue.for('observation', header_locale)),
+               title: TranslationValue.for('observation', header_locale),
                space_above: 0,
                space_below: 0.01,
                font_size: 13

--- a/app/views/latex/biographical_entries.pdf.erb
+++ b/app/views/latex/biographical_entries.pdf.erb
@@ -6,7 +6,7 @@
   header_text = "#{TranslationValue.for('biographical_entries_header', header_locale, interviewee_name: interviewee_name, archive_id: interview.archive_id)}"
 %>
 
-\title{<%= title %>}
+\title{<%= latex_multiscript(title) %>}
 
 \begin{document}
 
@@ -37,7 +37,7 @@
   <%= render partial: "latex/title",
     locals:
     {
-      title: latex_escape(title),
+      title: title,
       space_above: 0.4,
       space_below: 0,
       font_size: 12,

--- a/app/views/latex/biographical_entries.pdf.erb
+++ b/app/views/latex/biographical_entries.pdf.erb
@@ -44,5 +44,5 @@
     }
   %>
 
-  <%= raw biographical_entry.for_latex(header_locale) %>
+  <%= latex_sanitized_multiline_text(biographical_entry.text(header_locale)) %>
 <% end %>

--- a/app/views/latex/interview_observations.pdf.erb
+++ b/app/views/latex/interview_observations.pdf.erb
@@ -30,4 +30,4 @@
   }
 %>
 
-<%= raw interview.observations_for_latex(content_locale) %>
+<%= latex_multiline_text(interview.observations(content_locale), convert_quotes: true) %>

--- a/app/views/latex/interview_observations.pdf.erb
+++ b/app/views/latex/interview_observations.pdf.erb
@@ -6,7 +6,7 @@
   header_text = "#{TranslationValue.for('observations_header', header_locale, interviewee_name: interviewee_name, archive_id: interview.archive_id)}"
 %>
 
-\title{<%= title %>}
+\title{<%= latex_multiscript(title) %>}
 
 \begin{document}
 

--- a/app/views/latex/interview_transcript.pdf.erb
+++ b/app/views/latex/interview_transcript.pdf.erb
@@ -7,29 +7,32 @@
   interviewee_name = interview.interviewee.display_name
   content_locale_human_label = content_locale_human
 
-  title = [
+  title_plain = [
     tv("#{doc_type}_title", header_locale, lang: content_locale_human_label),
     interviewee_name
   ].join(" ")
 
-  header_text = [
+  header_text_plain = [
     tv("#{doc_type}_header", header_locale, lang: content_locale_human_label),
     interviewee_name,
     "(#{tv('archive_id', header_locale)} #{interview.archive_id})"
   ].join(" ")
 
+  title_latex = latex_multiscript(title_plain)
+  header_text_latex = latex_multiscript(header_text_plain)
+
   tape = 0
   speaker_id = nil
 %>
 
-\title{<%= title %>}
+\title{<%= title_latex %>}
 
 \begin{document}
 
 <%=
   render partial: "latex/header_footer",
     locals: {
-      header_text: header_text,
+      header_text: header_text_plain,
       interview: interview,
       header_locale: header_locale,
       doc_type: doc_type
@@ -39,7 +42,7 @@
 <%=
   render partial: "latex/title",
     locals: {
-      title: title,
+      title: title_plain,
       space_above: 3,
       space_below: 3,
       font_size: 18
@@ -85,7 +88,7 @@
 
 <%= render partial: "latex/title",
   locals: {
-    title: title,
+    title: title_plain,
     space_above: 0,
     space_below: 0.01,
     font_size: 13
@@ -100,7 +103,7 @@
       <% if tape != segment.tape.number %>
         <%= render partial: "latex/title",
           locals: {
-            title: latex_multiscript("#{tv('tape', header_locale)} #{segment.tape.number}"),
+            title: "#{tv('tape', header_locale)} #{segment.tape.number}",
             space_above: 0.7,
             space_below: 0.05,
             font_size: 10
@@ -151,7 +154,7 @@
 
         speaker_changed = previous_speaker_id.present? && previous_speaker_id != speaker_id
 
-        text = latex_multiscript(CGI.unescapeHTML(segment.text(content_locale_public)))
+        text = latex_multiscript(segment.text(content_locale_public))
     %>
 
     <% if ltr_speaker.present? %>

--- a/test/lib/latex_helper_test.rb
+++ b/test/lib/latex_helper_test.rb
@@ -78,6 +78,24 @@ class LatexHelperTest < ActiveSupport::TestCase
     assert_equal('A \\& B', latex_escape('A & B'))
   end
 
+  test 'latex_multiline_text escapes raw text once and preserves latex newline command' do
+    escaped = latex_multiline_text("A & B\nC % D")
+
+    assert_equal('A \\& B~\newline~C \\% D', escaped)
+  end
+
+  test 'latex_multiline_text converts quotes before escaping observations text' do
+    escaped = latex_multiline_text('"quoted" & raw', convert_quotes: true)
+
+    assert_equal('``quoted`` \\& raw', escaped)
+  end
+
+  test 'latex_sanitized_multiline_text strips html and escapes raw text once' do
+    escaped = latex_sanitized_multiline_text('<p>A &amp; B</p>')
+
+    assert_equal('A \\& B', escaped)
+  end
+
   test 'interview_date_for_pdf keeps multiple valid dates unchanged' do
     value = '03.07.2019,12.07.2019'
 


### PR DESCRIPTION
- Makes sure that strings used in LaTeX pdf generation are escaped once and only once.
- Moves latex escape out of models and to render boundary.
- Widens test coverage for escapes.